### PR TITLE
feat(home-manager/hyprland): source theme + accent

### DIFF
--- a/modules/home-manager/hyprland.nix
+++ b/modules/home-manager/hyprland.nix
@@ -1,19 +1,25 @@
-{ config
-, lib
-, sources
-, ...
+{
+  config,
+  lib,
+  sources,
+  ...
 }:
 let
   cfg = config.wayland.windowManager.hyprland.catppuccin;
   enable = cfg.enable && config.wayland.windowManager.hyprland.enable;
 in
 {
-  options.wayland.windowManager.hyprland.catppuccin =
-    lib.ctp.mkCatppuccinOpt "hyprland";
+  options.wayland.windowManager.hyprland.catppuccin = lib.ctp.mkCatppuccinOpt "hyprland" // {
+    accent = lib.ctp.mkAccentOpt "hyprland";
+  };
 
-  # Because of how nix merges options and hyprland interprets options, sourcing
-  # the file does not work. instead, parse the theme and put it in settings so
-  # the variables appear early enough in the file to be applied properly.
-  config.wayland.windowManager.hyprland.settings = lib.mkIf enable
-    (lib.ctp.fromINI (sources.hyprland + /themes/${cfg.flavour}.conf));
+  config.wayland.windowManager.hyprland.settings = lib.mkIf enable {
+    source = [
+      "${sources.hyprland}/themes/${cfg.flavour}.conf"
+      (builtins.toFile "hyprland-${cfg.accent}-accent.conf" ''
+        $accent=''$${cfg.accent}
+        $accentAlpha=''$${cfg.accent}Alpha
+      '')
+    ];
+  };
 }

--- a/modules/home-manager/hyprland.nix
+++ b/modules/home-manager/hyprland.nix
@@ -1,8 +1,7 @@
-{
-  config,
-  lib,
-  sources,
-  ...
+{ config
+, lib
+, sources
+, ...
 }:
 let
   cfg = config.wayland.windowManager.hyprland.catppuccin;


### PR DESCRIPTION
Since Home Manager defbb9c, Hyprland on Home Manager now sources files before most other configuration, meaning ctp-nix can now source a theme colors file instead of inserting them into the main configuration. In addition, accent and accentAlpha color variables have been added in a second sourced file.