### PR TITLE
feat(home-manager): init fzf module

### DIFF
--- a/modules/home-manager/fzf.nix
+++ b/modules/home-manager/fzf.nix
@@ -1,0 +1,35 @@
+{ config
+, lib
+, sources
+, ...
+}:
+let
+  cfg = config.programs.fzf.catppuccin;
+  enable = cfg.enable && config.programs.fzf.enable;
+  palette = (lib.importJSON "${sources.palette}/palette.json").${cfg.flavour}.colors;
+in
+{
+  options.programs.fzf.catppuccin =
+    lib.ctp.mkCatppuccinOpt "fzf";
+
+  config.programs.fzf.colors = lib.mkIf enable
+    # Manually populate with colors from catppuccin/fzf
+    # The ordering is meant to match the order of catppuccin/fzf to make comparison easier
+    (lib.attrsets.mapAttrs (_: color: palette.${color}.hex)
+      {
+        "bg+" = "surface0";
+        bg = "base";
+        spinner = "rosewater";
+        hl = "red";
+        fg = "text";
+        header = "red";
+        info = "mauve";
+        pointer = "rosewater";
+        marker = "rosewater";
+        "fg+" = "text";
+        prompt = "mauve";
+        "hl+" = "red";
+      }
+    );
+}
+

--- a/test.nix
+++ b/test.nix
@@ -59,6 +59,7 @@ in
         bottom = ctpEnable;
         btop = ctpEnable;
         fish = ctpEnable;
+        fzf = ctpEnable;
         git.enable = true; # Required for delta
         git.delta = ctpEnable;
         glamour.catppuccin.enable = true;


### PR DESCRIPTION
Adds support for fzf.

I took the same approach that the console module uses and used the palette to manually add the colors from [catppuccin/fzf](https://github.com/catppuccin/fzf).