### PR TITLE
fix(home-manager): gtk cursor activation

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -58,7 +58,7 @@ in
         accentUpper = ctp.mkUpper cfg.cursor.accent;
       in
       lib.mkIf cfg.cursor.enable {
-        name = "Catppuccin-${flavourUpper}-${accentUpper}";
+        name = "Catppuccin-${flavourUpper}-${accentUpper}-Cursors";
         package = pkgs.catppuccin-cursors.${cfg.cursor.flavour + accentUpper};
       };
   };


### PR DESCRIPTION
Resolves #105 by renaming the gtk cursorTheme