### PR TITLE
fix(home-manager): link GTK 4.0 files

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -63,6 +63,10 @@ in
       };
   };
 
+  config.assertions = [
+    (lib.ctp.assertXdgEnabled "gtk")
+  ];
+
   config.xdg.configFile = lib.mkIf enable {
     "gtk-4.0/assets".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/assets";
     "gtk-4.0/gtk.css".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/gtk.css";

--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -31,6 +31,10 @@ in
     };
 
   config = lib.mkIf enable {
+    assertions = [
+      (lib.ctp.assertXdgEnabled "gtk")
+    ];
+
     gtk = {
       theme =
         let
@@ -64,14 +68,14 @@ in
         };
     };
 
-    assertions = [
-      (lib.ctp.assertXdgEnabled "gtk")
-    ];
-
-    xdg.configFile = {
-      "gtk-4.0/assets".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/assets";
-      "gtk-4.0/gtk.css".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/gtk.css";
-      "gtk-4.0/gtk-dark.css".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/gtk-dark.css";
+    xdg.configFile =
+      let
+        gtk4Dir = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0";
+      in
+      {
+      "gtk-4.0/assets".source = "${gtk4Dir}/assets";
+      "gtk-4.0/gtk.css".source = "${gtk4Dir}/gtk.css";
+      "gtk-4.0/gtk-dark.css".source = "${gtk4Dir}/gtk-dark.css";
     };
   };
 }

--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -73,9 +73,9 @@ in
         gtk4Dir = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0";
       in
       {
-      "gtk-4.0/assets".source = "${gtk4Dir}/assets";
-      "gtk-4.0/gtk.css".source = "${gtk4Dir}/gtk.css";
-      "gtk-4.0/gtk-dark.css".source = "${gtk4Dir}/gtk-dark.css";
-    };
+        "gtk-4.0/assets".source = "${gtk4Dir}/assets";
+        "gtk-4.0/gtk.css".source = "${gtk4Dir}/gtk.css";
+        "gtk-4.0/gtk-dark.css".source = "${gtk4Dir}/gtk-dark.css";
+      };
   };
 }

--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -30,46 +30,48 @@ in
       };
     };
 
-  config.gtk = lib.mkIf enable {
-    theme =
-      let
-        flavourUpper = ctp.mkUpper cfg.flavour;
-        accentUpper = ctp.mkUpper cfg.accent;
-        sizeUpper = ctp.mkUpper cfg.size;
+  config = lib.mkIf enable {
+    gtk = {
+      theme =
+        let
+          flavourUpper = ctp.mkUpper cfg.flavour;
+          accentUpper = ctp.mkUpper cfg.accent;
+          sizeUpper = ctp.mkUpper cfg.size;
 
-        # use the light gtk theme for latte
-        gtkTheme =
-          if cfg.flavour == "latte"
-          then "Light"
-          else "Dark";
-      in
-      {
-        name = "Catppuccin-${flavourUpper}-${sizeUpper}-${accentUpper}-${gtkTheme}";
-        package = pkgs.catppuccin-gtk.override {
-          inherit (cfg) size tweaks;
-          accents = [ cfg.accent ];
-          variant = cfg.flavour;
+          # use the light gtk theme for latte
+          gtkTheme =
+            if cfg.flavour == "latte"
+            then "Light"
+            else "Dark";
+        in
+        {
+          name = "Catppuccin-${flavourUpper}-${sizeUpper}-${accentUpper}-${gtkTheme}";
+          package = pkgs.catppuccin-gtk.override {
+            inherit (cfg) size tweaks;
+            accents = [ cfg.accent ];
+            variant = cfg.flavour;
+          };
         };
-      };
 
-    cursorTheme =
-      let
-        flavourUpper = ctp.mkUpper cfg.cursor.flavour;
-        accentUpper = ctp.mkUpper cfg.cursor.accent;
-      in
-      lib.mkIf cfg.cursor.enable {
-        name = "Catppuccin-${flavourUpper}-${accentUpper}-Cursors";
-        package = pkgs.catppuccin-cursors.${cfg.cursor.flavour + accentUpper};
-      };
-  };
+      cursorTheme =
+        let
+          flavourUpper = ctp.mkUpper cfg.cursor.flavour;
+          accentUpper = ctp.mkUpper cfg.cursor.accent;
+        in
+        lib.mkIf cfg.cursor.enable {
+          name = "Catppuccin-${flavourUpper}-${accentUpper}-Cursors";
+          package = pkgs.catppuccin-cursors.${cfg.cursor.flavour + accentUpper};
+        };
+    };
 
-  config.assertions = [
-    (lib.ctp.assertXdgEnabled "gtk")
-  ];
+    assertions = [
+      (lib.ctp.assertXdgEnabled "gtk")
+    ];
 
-  config.xdg.configFile = lib.mkIf enable {
-    "gtk-4.0/assets".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/assets";
-    "gtk-4.0/gtk.css".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/gtk.css";
-    "gtk-4.0/gtk-dark.css".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/gtk-dark.css";
+    xdg.configFile = {
+      "gtk-4.0/assets".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/assets";
+      "gtk-4.0/gtk.css".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/gtk.css";
+      "gtk-4.0/gtk-dark.css".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/gtk-dark.css";
+    };
   };
 }

--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -62,4 +62,10 @@ in
         package = pkgs.catppuccin-cursors.${cfg.cursor.flavour + accentUpper};
       };
   };
+
+  config.xdg.configFile = lib.mkIf enable {
+    "gtk-4.0/assets".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/assets";
+    "gtk-4.0/gtk.css".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/gtk.css";
+    "gtk-4.0/gtk-dark.css".source = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}/gtk-4.0/gtk-dark.css";
+  };
 }


### PR DESCRIPTION
Adds links go GTK 4.0 files as suggested in the [catppuccin/gtk](https://github.com/catppuccin/gtk) README. Closes #107.