### PR TITLE
feat(home-manager): allow `dark` and `light` accents for gtk cursors

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -7,6 +7,8 @@ let
   inherit (lib) ctp mkOption types;
   cfg = config.gtk.catppuccin;
   enable = cfg.enable && config.gtk.enable;
+  # "dark" and "light" can be used alongside the regular accents
+  cursorAccentType = ctp.mergeEnums (ctp.types.accentOption) (lib.types.enum [ "dark" "light" ]);
 in
 {
   options.gtk.catppuccin =
@@ -26,7 +28,7 @@ in
 
       cursor = ctp.mkCatppuccinOpt "gtk cursors"
       // {
-        accent = ctp.mkAccentOpt "gtk cursors";
+        accent = ctp.mkBasicOpt "accent" cursorAccentType "gtk cursors";
       };
     };
 

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -100,4 +100,9 @@ in
     assertion = config.xdg.enable;
     message = "Option xdg.enable must be enabled to apply Catppuccin theming for ${name}";
   };
+
+  # see https://nlewo.github.io/nixos-manual-sphinx/development/option-types.xml.html
+  # by default enums cannot be merged, but they keep their passed value in `functor.payload`.
+  # `functor.binOp` can merge those values
+  mergeEnums = a: b: lib.types.enum (a.functor.binOp a.functor.payload b.functor.payload);
 }


### PR DESCRIPTION
This is a bit hacky solution, but I can build my system with `gtk.catppuccin.cursor.accent = "dark"` now.

Feel free to correct my comments, I feel they are grammatically wrong, but don't know how to write better.