### PR TITLE
fix(home-manager): add file for yazi syntax highlighting

### DIFF
--- a/modules/home-manager/yazi.nix
+++ b/modules/home-manager/yazi.nix
@@ -13,6 +13,11 @@ in
     ctp.mkCatppuccinOpt "yazi";
 
   config = lib.mkIf enable {
+    assertions = [
+      (lib.ctp.assertXdgEnabled "yazi")
+    ];
+
     programs.yazi.theme = lib.importTOML "${sources.yazi}/themes/${cfg.flavour}.toml";
+    xdg.configFile."yazi/Catppuccin-${cfg.flavour}.tmTheme".source = "${sources.bat}/themes/Catppuccin ${ctp.mkUpper cfg.flavour}.tmTheme";
   };
 }


### PR DESCRIPTION
Fixes #111 