### PR TITLE
feat(home-manager): add support for foot

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -139,6 +139,26 @@
         },
         "version": "0ce27b518e8ead555dec34dd8be3df5bd75cff8e"
     },
+    "foot": {
+        "cargoLocks": null,
+        "date": "2024-01-18",
+        "extract": null,
+        "name": "foot",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "foot",
+            "rev": "ee5549af72ab78520ac2aa1c671bf5c2d347c8ca",
+            "sha256": "sha256-3hK9klXwdHhprG2wUMt7nBfbL1mb/gl+k/MtJUuY000=",
+            "type": "github"
+        },
+        "version": "ee5549af72ab78520ac2aa1c671bf5c2d347c8ca"
+    },
     "gitui": {
         "cargoLocks": null,
         "date": "2023-11-13",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -85,6 +85,18 @@
     };
     date = "2023-11-02";
   };
+  foot = {
+    pname = "foot";
+    version = "ee5549af72ab78520ac2aa1c671bf5c2d347c8ca";
+    src = fetchFromGitHub {
+      owner = "catppuccin";
+      repo = "foot";
+      rev = "ee5549af72ab78520ac2aa1c671bf5c2d347c8ca";
+      fetchSubmodules = false;
+      sha256 = "sha256-3hK9klXwdHhprG2wUMt7nBfbL1mb/gl+k/MtJUuY000=";
+    };
+    date = "2024-01-18";
+  };
   gitui = {
     pname = "gitui";
     version = "39978362b2c88b636cacd55b65d2f05c45a47eb9";

--- a/modules/home-manager/foot.nix
+++ b/modules/home-manager/foot.nix
@@ -1,0 +1,15 @@
+{ config
+, lib
+, sources
+, ...
+}:
+let
+  cfg = config.programs.foot.catppuccin;
+  enable = cfg.enable && config.programs.foot.enable;
+  theme = lib.ctp.fromINI (sources.foot + /catppuccin-${cfg.flavour}.ini);
+in
+{
+  options.programs.foot.catppuccin = lib.ctp.mkCatppuccinOpt "foot";
+
+  config.programs.foot = lib.mkIf enable { settings = theme; };
+}

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -26,6 +26,10 @@ fetch.github = "catppuccin/dunst"
 src.git = "https://github.com/catppuccin/fish.git"
 fetch.github = "catppuccin/fish"
 
+[foot]
+src.git = "https://github.com/catppuccin/foot.git"
+fetch.github = "catppuccin/foot"
+
 [gitui]
 src.git = "https://github.com/catppuccin/gitui.git"
 fetch.github = "catppuccin/gitui"

--- a/test.nix
+++ b/test.nix
@@ -59,6 +59,7 @@ in
         bottom = ctpEnable;
         btop = ctpEnable;
         fish = ctpEnable;
+        foot = ctpEnable;
         fzf = ctpEnable;
         git.enable = true; # Required for delta
         git.delta = ctpEnable;


### PR DESCRIPTION
Adds support for foot.

Closes #14 .

PS: `lib.ctp.fromINI` includes comments in variable values. Not a problem here, but might be somewhere else in the future.