### PR TITLE
feat(home-manager): add support for cava

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -79,6 +79,26 @@
         },
         "version": "c6469190f2ecf25f017d6120bf4e050e6b1d17af"
     },
+    "cava": {
+        "cargoLocks": null,
+        "date": "2024-04-01",
+        "extract": null,
+        "name": "cava",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "cava",
+            "rev": "56c1e69318856a853b28e3ccce500c00099dc051",
+            "sha256": "sha256-FNNEYFurT6Y6rkKrvyAGt+3a+7GO4UE5el2sJ2ZKX2k=",
+            "type": "github"
+        },
+        "version": "56c1e69318856a853b28e3ccce500c00099dc051"
+    },
     "delta": {
         "cargoLocks": null,
         "date": "2024-03-23",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -49,6 +49,18 @@
     };
     date = "2023-10-07";
   };
+  cava = {
+    pname = "cava";
+    version = "56c1e69318856a853b28e3ccce500c00099dc051";
+    src = fetchFromGitHub {
+      owner = "catppuccin";
+      repo = "cava";
+      rev = "56c1e69318856a853b28e3ccce500c00099dc051";
+      fetchSubmodules = false;
+      sha256 = "sha256-FNNEYFurT6Y6rkKrvyAGt+3a+7GO4UE5el2sJ2ZKX2k=";
+    };
+    date = "2024-04-01";
+  };
   delta = {
     pname = "delta";
     version = "765eb17d0268bf07c20ca439771153f8bc79444f";

--- a/modules/home-manager/cava.nix
+++ b/modules/home-manager/cava.nix
@@ -1,0 +1,18 @@
+{ config
+, lib
+, sources
+, ...
+}:
+let
+  inherit (lib) ctp;
+  cfg = config.programs.cava.catppuccin;
+  enable = cfg.enable && config.programs.cava.enable;
+in
+{
+  options.programs.cava.catppuccin =
+    lib.ctp.mkCatppuccinOpt "cava";
+
+  config.programs.cava = lib.mkIf enable {
+    settings = lib.ctp.fromINIRaw (sources.cava + /themes/${cfg.flavour}.cava);
+  };
+}

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -1,4 +1,8 @@
-{ config, lib, pkgs, ... }:
+{ config
+, lib
+, pkgs
+, ...
+}:
 let
   # string -> type -> string -> a -> a
   # this is an internal function and shouldn't be
@@ -76,6 +80,21 @@ in
       json = with pkgs;
         runCommand "converted.json" { } ''
           ${jc}/bin/jc --ini < ${file} > $out
+        '';
+    in
+    fromJSON (readFile json);
+
+  # a -> path -> a
+  # fromJSON but for raw ini (and without readFile)
+  # a should be the local pkgs attrset
+  fromINIRaw = file:
+    let
+      inherit (builtins) fromJSON readFile;
+
+      # convert to json
+      json = with pkgs;
+        runCommand "converted.json" { } ''
+          ${jc}/bin/jc --ini -r < ${file} > $out
         '';
     in
     fromJSON (readFile json);

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -14,6 +14,10 @@ fetch.github = "catppuccin/bottom"
 src.git = "https://github.com/catppuccin/btop.git"
 fetch.github = "catppuccin/btop"
 
+[cava]
+src.git = "https://github.com/catppuccin/cava.git"
+fetch.github = "catppuccin/cava"
+
 [delta]
 src.git = "https://github.com/catppuccin/delta.git"
 fetch.github = "catppuccin/delta"

--- a/test.nix
+++ b/test.nix
@@ -58,6 +58,7 @@ in
         bat = ctpEnable;
         bottom = ctpEnable;
         btop = ctpEnable;
+        cava = ctpEnable;
         fish = ctpEnable;
         fzf = ctpEnable;
         git.enable = true; # Required for delta


### PR DESCRIPTION
Adds support for cava.

I went ahead with duplicating the code for raw parsing the ini file (by using the `-r` parameter for `jc`) as `cava` requires the quotation marks for recognizing hexadecimal color strings.