### PR TITLE
fix(home-manager): allow overriding styles for the rofi theme

### DIFF
--- a/modules/home-manager/rofi.nix
+++ b/modules/home-manager/rofi.nix
@@ -13,9 +13,11 @@ in
     lib.ctp.mkCatppuccinOpt "rofi";
 
   config.programs.rofi = lib.mkIf enable {
-    theme = builtins.path {
-      name = "catppuccin-${cfg.flavour}.rasi";
-      path = "${sources.rofi}/basic/.local/share/rofi/themes/catppuccin-${cfg.flavour}.rasi";
+    theme = {
+      "@theme" = builtins.path {
+        name = "catppuccin-${cfg.flavour}.rasi";
+        path = "${sources.rofi}/basic/.local/share/rofi/themes/catppuccin-${cfg.flavour}.rasi";
+      };
     };
   };
 }


### PR DESCRIPTION
Fix for #122.

Alters `programs.rofi.theme` to use an attrset instead of a path directly, so that users can add overriding styles to `programs.rofi.theme`.

A minimal example of how to change the font used in the theme would look like the following:

```nix
{
  programs.rofi = {
    enable = true;

    catppuccin.enable = true;

    theme."*".font = "monospace 14";
}
```

I've tested the changes with my NixOS/home-manager configuration, and it seems to work fine.