### PR TITLE
feat(home-manager): add transparent option for k9s

### DIFF
--- a/modules/home-manager/k9s.nix
+++ b/modules/home-manager/k9s.nix
@@ -7,22 +7,27 @@ let
   cfg = config.programs.k9s.catppuccin;
   enable = cfg.enable && config.programs.k9s.enable;
 
-  themeFile = "catppuccin-${cfg.flavour}.yaml";
+  themeName = "catppuccin-${cfg.flavour}" + lib.optionalString cfg.transparent "-transparent";
+  themeFile = "${themeName}.yaml";
   themePath = "/skins/${themeFile}";
   theme = sources.k9s + "/dist/${themeFile}";
 in
 {
   options.programs.k9s.catppuccin =
-    lib.ctp.mkCatppuccinOpt "k9s";
-
-  config = lib.mkIf enable
-    {
-      assertions = [
-        (lib.ctp.assertXdgEnabled "k9s")
-      ];
-
-      xdg.configFile."k9s${themePath}".source = theme;
-
-      programs.k9s.settings.k9s.ui.skin = "catppuccin-${cfg.flavour}";
+    lib.ctp.mkCatppuccinOpt "k9s"
+    // {
+      transparent = lib.mkEnableOption "transparent version of flavour";
     };
+
+  config =
+    lib.mkIf enable
+      {
+        assertions = [
+          (lib.ctp.assertXdgEnabled "k9s")
+        ];
+
+        xdg.configFile."k9s${themePath}".source = theme;
+
+        programs.k9s.settings.k9s.ui.skin = themeName;
+      };
 }


### PR DESCRIPTION
Adds option `transparent` to use the transparent version of the variants. By default, the non-transparent variants override the background colors.