### PR TITLE
feat(home-manager): add support for zellij

### DIFF
--- a/modules/home-manager/zellij.nix
+++ b/modules/home-manager/zellij.nix
@@ -1,0 +1,17 @@
+{ config
+, lib
+, ...
+}:
+let
+  cfg = config.programs.zellij.catppuccin;
+  enable = cfg.enable && config.programs.zellij.enable;
+  themeName = "catppuccin-${cfg.flavour}";
+in
+{
+  options.programs.zellij.catppuccin =
+    lib.ctp.mkCatppuccinOpt "zellij";
+
+  config = lib.mkIf enable {
+    programs.zellij.settings = { theme = themeName; };
+  };
+}

--- a/test.nix
+++ b/test.nix
@@ -87,6 +87,7 @@ in
         tmux = ctpEnable;
         yazi = ctpEnable;
         zathura = ctpEnable;
+        zellij = ctpEnable;
       };
 
       gtk = lib.recursiveUpdate ctpEnable { catppuccin.cursor.enable = true; };


### PR DESCRIPTION
Catppuccin is included in zellij and can be enabled as the [official source](https://github.com/catppuccin/zellij?tab=readme-ov-file#usage) instructs.

![Screenshot from 2024-04-22 16-31-34](https://github.com/catppuccin/nix/assets/83901271/f1504d41-376b-4738-95b4-6bd4d3f93d64)