### PR TITLE
feat(home-manager/fcitx5): add apply option

### DIFF
--- a/modules/home-manager/fcitx5.nix
+++ b/modules/home-manager/fcitx5.nix
@@ -9,7 +9,16 @@ let
   enable = cfg.enable && config.i18n.inputMethod.enabled == "fcitx5";
 in
 {
-  options.i18n.inputMethod.fcitx5.catppuccin = ctp.mkCatppuccinOpt "Fcitx5";
+  options.i18n.inputMethod.fcitx5.catppuccin = ctp.mkCatppuccinOpt "Fcitx5" // {
+    apply = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Applies the theme by overwriting `$XDG_CONFIG_HOME/fcitx5/conf/classicui.conf`.
+        If this is disabled, you must manually set the theme (e.g. by using `fcitx5-configtool`).
+      '';
+    };
+  };
 
   config = lib.mkIf enable {
     assertions = [
@@ -21,8 +30,10 @@ in
       recursive = true;
     };
 
-    xdg.configFile."fcitx5/conf/classicui.conf".text = lib.generators.toINIWithGlobalSection { } {
-      globalSection.Theme = "catppuccin-${cfg.flavour}";
-    };
+    xdg.configFile."fcitx5/conf/classicui.conf" = lib.mkIf cfg.apply ({
+      text = lib.generators.toINIWithGlobalSection { } {
+        globalSection.Theme = "catppuccin-${cfg.flavour}";
+      };
+    });
   };
 }


### PR DESCRIPTION
The current implementation overrides the configuration for fcitx5 classical ui. This prevents users from changing different ui settings apart from the theme. This adds the ability to optionally install the theme without applying.