### PR TITLE
fix: make dark/light lowecase for style names in gtk

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -47,8 +47,8 @@ in
           # use the light gtk theme for latte
           gtkTheme =
             if cfg.flavour == "latte"
-            then "Light"
-            else "Dark";
+            then "light"
+            else "dark";
         in
         {
           name = "Catppuccin-${flavourUpper}-${sizeUpper}-${accentUpper}-${gtkTheme}";


### PR DESCRIPTION
I tried to use Latte flavour, but all window titles are black. The reason of that I think is here: https://github.com/catppuccin/gtk/issues/100, so we need to use `dark` and `light` instead of `Dark` and `Light` in style.

current style:
![image](https://github.com/catppuccin/nix/assets/2993917/0bbd98da-3b90-4ae4-8094-0293870bb78b)


fixed style:
![image](https://github.com/catppuccin/nix/assets/2993917/0ce40a1b-a9a8-48f8-9002-b59242219948)
