### PR TITLE
feat(home-manager): add support for swaync

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -44,6 +44,7 @@
   ./starship.nix
   ./swaylock.nix
   ./sway.nix
+  ./swaync.nix
   ./thunderbird.nix
   ./tmux.nix
   ./tofi.nix

--- a/modules/home-manager/swaync.nix
+++ b/modules/home-manager/swaync.nix
@@ -1,0 +1,53 @@
+{ catppuccinLib }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (config.catppuccin) sources;
+  cfg = config.catppuccin.swaync;
+
+  enable = cfg.enable && config.services.swaync.enable;
+
+  theme = pkgs.substitute {
+    src = sources.swaync + "/${cfg.flavor}.css";
+
+    substitutions = [
+      "--replace-warn"
+      "Ubuntu Nerd Font"
+      cfg.font
+    ];
+  };
+in
+
+{
+  options.catppuccin.swaync =
+    catppuccinLib.mkCatppuccinOption {
+      name = "swaync";
+    }
+    // {
+      font = lib.mkOption {
+        type = lib.types.str;
+        default = "Ubuntu Nerd Font";
+        description = "Font to use for the notification center";
+      };
+    };
+
+  config = lib.mkIf enable {
+    services.swaync.style = theme;
+
+    # Install the default font if it is selected
+    home.packages = lib.mkIf (cfg.font == "Ubuntu Nerd Font") [
+      # TODO: Remove when 25.05 is stable and `nerdfonts` is fully deprecated
+      (
+        if pkgs ? "nerd-fonts" then
+          pkgs.nerd-fonts.ubuntu
+        else
+          pkgs.nerdfonts.override { fonts = [ "Ubuntu" ]; }
+      )
+    ];
+  };
+}

--- a/modules/tests/darwin.nix
+++ b/modules/tests/darwin.nix
@@ -47,6 +47,7 @@
           dunst.enable = lib.mkVMOverride false;
           mako.enable = lib.mkVMOverride false;
           polybar.enable = lib.mkVMOverride false;
+          swaync.enable = lib.mkVMOverride false;
         };
 
         wayland.windowManager = {

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -96,6 +96,7 @@
         polybar top &
       '';
     };
+    swaync.enable = true;
   };
 
   wayland.windowManager.sway.enable = true;

--- a/pkgs/swaync/package.nix
+++ b/pkgs/swaync/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchurl,
+  linkFarm,
+}:
+
+let
+  version = "0.2.3";
+
+  artifactHashes = {
+    "frappe.css" = "sha256-9vfro7HpA2T5bk1So8kjUKSXwe5Qnqji7bhs5ASs/Pg=";
+    "latte.css" = "sha256-Xp7BekqhHUVTiEMMKKeEO9jlL1wtujlFSU0SINNtWZQ=";
+    "macchiato.css" = "sha256-LMm6nWn1JPPgj5YpppwFG3lXTtXem5atlIvqrDxd0bM=";
+    "mocha.css" = "sha256-Hie/vDt15nGCy4XWERGy1tUIecROw17GOoasT97kIfc=";
+  };
+in
+
+linkFarm "catppuccin-swaync-${version}" (
+  lib.mapAttrs (
+    artifactName: hash:
+
+    fetchurl {
+      url = "https://github.com/catppuccin/swaync/releases/download/v${version}/${artifactName}";
+      inherit hash;
+    }
+  ) artifactHashes
+)


### PR DESCRIPTION
Ready-to-use css files are only provided as release artifacts.
We could also build these ourselves, but would need to manually update the `npmDepsHash`.

The default font used in the theme is "Ubuntu Nerd Font".
Adding it to `home.packages` is not possible as I query that for `enable` and thus would result in infinite recursion.

For the option name I referred to https://github.com/nix-community/home-manager/pull/4249 and https://github.com/nix-community/home-manager/pull/5345.