### PR TITLE
chore(sources/gtk): remove dangling source

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -279,26 +279,6 @@
         },
         "version": "88f6124757331fd3a37c8a69473021389b7663ad"
     },
-    "gtk": {
-        "cargoLocks": null,
-        "date": "2024-04-20",
-        "extract": null,
-        "name": "gtk",
-        "passthru": null,
-        "pinned": false,
-        "src": {
-            "deepClone": false,
-            "fetchSubmodules": false,
-            "leaveDotGit": false,
-            "name": null,
-            "owner": "catppuccin",
-            "repo": "gtk",
-            "rev": "9da440ced621d1bff58676efdcec9f64284c52a6",
-            "sha256": "sha256-pGL8vaE63ss2ZT2FoNDfDkeuCxjcbl02RmwwfHC/Vxg=",
-            "type": "github"
-        },
-        "version": "9da440ced621d1bff58676efdcec9f64284c52a6"
-    },
     "helix": {
         "cargoLocks": null,
         "date": "2024-03-30",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -169,18 +169,6 @@
     };
     date = "2024-03-07";
   };
-  gtk = {
-    pname = "gtk";
-    version = "9da440ced621d1bff58676efdcec9f64284c52a6";
-    src = fetchFromGitHub {
-      owner = "catppuccin";
-      repo = "gtk";
-      rev = "9da440ced621d1bff58676efdcec9f64284c52a6";
-      fetchSubmodules = false;
-      sha256 = "sha256-pGL8vaE63ss2ZT2FoNDfDkeuCxjcbl02RmwwfHC/Vxg=";
-    };
-    date = "2024-04-20";
-  };
   helix = {
     pname = "helix";
     version = "0164c4ca888084df4f511da22c6a0a664b5061d2";

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -54,10 +54,6 @@ fetch.github = "catppuccin/glamour"
 src.git = "https://github.com/catppuccin/grub.git"
 fetch.github = "catppuccin/grub"
 
-[gtk]
-src.git = "https://github.com/catppuccin/gtk.git"
-fetch.github = "catppuccin/gtk"
-
 [helix]
 src.git = "https://github.com/catppuccin/helix.git"
 fetch.github = "catppuccin/helix"


### PR DESCRIPTION
The gtk home-manager module uses catppuccin-gtk packaged in nixpkgs. This source is not used.