### PR TITLE
fix(home-manager/gtk): capitalize gtkTheme

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -47,8 +47,8 @@ in
           # use the light gtk theme for latte
           gtkTheme =
             if cfg.flavour == "latte"
-            then "light"
-            else "dark";
+            then "Light"
+            else "Dark";
         in
         {
           name = "Catppuccin-${flavourUpper}-${sizeUpper}-${accentUpper}-${gtkTheme}";


### PR DESCRIPTION
The uncapitalized gtkTheme made the generated theme name incorrect wich prevented the theme to be set correctly and made the symlinks in ~/.config/gtk-4.0 broken