### PR TITLE
feat(modules/nixos): add global `accent` option

### DIFF
--- a/modules/nixos/globals.nix
+++ b/modules/nixos/globals.nix
@@ -7,5 +7,11 @@
       default = "mocha";
       description = "Global Catppuccin flavour";
     };
+
+    accent = lib.mkOption {
+      type = lib.ctp.types.accentOption;
+      default = "mauve";
+      description = "Global Catppuccin accent";
+    };
   };
 }


### PR DESCRIPTION
Literally just a copy-paste from the home-manager module
Currently it does nothing, added for consistency

Closes #134