### PR TITLE
feat(home-manager/cava): add support for themes with transparent background

### DIFF
--- a/.sources/sources.json
+++ b/.sources/sources.json
@@ -56,9 +56,9 @@
         "repo": "cava"
       },
       "branch": "main",
-      "revision": "56c1e69318856a853b28e3ccce500c00099dc051",
-      "url": "https://github.com/catppuccin/cava/archive/56c1e69318856a853b28e3ccce500c00099dc051.tar.gz",
-      "hash": "0saz99k2gb2xg8wl3qcfn7xxmvdp0qhbzas2mqxackxbbdh49lql"
+      "revision": "6ec25ba688e30f3e5d6004ef6a295e6ba90c64d4",
+      "url": "https://github.com/catppuccin/cava/archive/6ec25ba688e30f3e5d6004ef6a295e6ba90c64d4.tar.gz",
+      "hash": "0nqpddlff1x5igipn9wc2ipagj53s0b63vp1zm3z6lzwlx8q5q6p"
     },
     "delta": {
       "type": "Git",

--- a/modules/home-manager/cava.nix
+++ b/modules/home-manager/cava.nix
@@ -3,11 +3,14 @@ let
   inherit (config.catppuccin) sources;
   cfg = config.programs.cava.catppuccin;
   enable = cfg.enable && config.programs.cava.enable;
+  flavor = "${cfg.flavor}" + lib.optionalString cfg.transparent "-transparent";
 in
 {
-  options.programs.cava.catppuccin = lib.ctp.mkCatppuccinOpt "cava";
+  options.programs.cava.catppuccin = lib.ctp.mkCatppuccinOpt "cava" // {
+    transparent = lib.mkEnableOption "transparent version of flavor";
+  };
 
   config.programs.cava = lib.mkIf enable {
-    settings = lib.ctp.fromINIRaw (sources.cava + "/themes/${cfg.flavor}.cava");
+    settings = lib.ctp.fromINIRaw (sources.cava + "/themes/${flavor}.cava");
   };
 }


### PR DESCRIPTION
# Description

This PR adds a new option to the `programs.cava.catppuccin` module, called `transparent`. Similarly to the `programs.k9s.catppuccin.transparent`, it is a boolean used to select the flavor variant with a transparent background.

This new feature has been added in this PR: https://github.com/catppuccin/cava/pull/11, the source for `cava` therefore needs to be updated.

This should not be a breaking change, as the option defaults to `false`, which will in turn use the same theme file as currently.

**Note**: this PR is still in draft until the aforementioned PR in the source repo is merged, at which time the second commit will be updated to track catppuccin/cava.