### PR TITLE
fix(nixos): sddm package not being installed 

### DIFF
--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -27,7 +27,7 @@ in
   # this creates a flavor option for modules
   # the first string should be the name of the module,
   # followed by the local config attrset
-  mkFlavourOpt = ctp.mkBasicOpt "flavor" ctp.types.flavorOption;
+  mkFlavorOpt = ctp.mkBasicOpt "flavor" ctp.types.flavorOption;
 
   types = {
     flavorOption = lib.types.enum [
@@ -114,7 +114,7 @@ in
     enable = lib.mkEnableOption "Catppuccin theme" // {
       default = config.catppuccin.enable;
     };
-    flavor = ctp.mkFlavourOpt name;
+    flavor = ctp.mkFlavorOpt name;
   };
 
   # string -> a -> a

--- a/modules/nixos/sddm.nix
+++ b/modules/nixos/sddm.nix
@@ -13,12 +13,16 @@ let
     versionAtLeast
     ;
   cfg = config.services.displayManager.sddm.catppuccin;
-  enable = cfg.enable && config.services.displayManager.sddm.enable;
+  enable =
+    versionAtLeast ctp.getModuleRelease minVersion
+    && cfg.enable
+    && config.services.displayManager.sddm.enable;
 
   # versions >= 24.05 renamed `services.xserver.displayManager` to `services.displayManager`
   # TODO: remove when 24.05 is stable
   minVersion = "24.05";
 in
+
 {
   options.services.displayManager = ctp.mkVersionedOpts minVersion {
     sddm.catppuccin = ctp.mkCatppuccinOpt "sddm" // {
@@ -48,21 +52,18 @@ in
     };
   };
 
-  config =
-    mkIf enable {
-      environment.systemPackages = [
-        (pkgs.catppuccin-sddm.override {
-          inherit (cfg)
-            flavor
-            font
-            fontSize
-            background
-            loginBackground
-            ;
-        })
-      ];
-    }
-    // mkIf (enable && versionAtLeast ctp.getModuleRelease minVersion) {
-      services.displayManager.sddm.theme = "catppuccin-${cfg.flavor}";
-    };
+  config = mkIf enable {
+    services.displayManager.sddm.theme = "catppuccin-${cfg.flavor}";
+    environment.systemPackages = [
+      (pkgs.catppuccin-sddm.override {
+        inherit (cfg)
+          flavor
+          font
+          fontSize
+          background
+          loginBackground
+          ;
+      })
+    ];
+  };
 }


### PR DESCRIPTION
Never use attrset merge operator with `mk*` attrsets since the right hand attrset overrides the left

Fixes #192