### PR TITLE
ci(release-please): use action from googleapis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: simple
           package-name: catppuccin/nix


### PR DESCRIPTION
I confirmed that it shouldn't break anything
from looking at the documentation, but who
knows with release-please /shrug