### PR TITLE
feat(home-manager): add support for fuzzel

### DIFF
--- a/.sources/sources.json
+++ b/.sources/sources.json
@@ -120,6 +120,18 @@
       "url": "https://github.com/catppuccin/foot/archive/80756a4d63ea4fae4d0fdd793017370f8b8b12ac.tar.gz",
       "hash": "12a3znfdjpiqrylpv009cvi4w4dgw4i6kxk5gm959y72gybbpbw7"
     },
+    "fuzzel": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "catppuccin",
+        "repo": "fuzzel"
+      },
+      "branch": "main",
+      "revision": "eeb4c8d159187ef7eb59a4a99baec67c2e797e9f",
+      "url": "https://github.com/catppuccin/fuzzel/archive/eeb4c8d159187ef7eb59a4a99baec67c2e797e9f.tar.gz",
+      "hash": "0h0vd1l0hq7bgnga0lbx2564fwlh9riwahx1fr2dr09gi9ry36y8"
+    },
     "gh-dash": {
       "type": "Git",
       "repository": {

--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -9,6 +9,7 @@
   ./fcitx5.nix
   ./fish.nix
   ./foot.nix
+  ./fuzzel.nix
   ./fzf.nix
   ./gh-dash.nix
   ./gitui.nix

--- a/modules/home-manager/fuzzel.nix
+++ b/modules/home-manager/fuzzel.nix
@@ -1,0 +1,14 @@
+{ config, lib, ... }:
+let
+  inherit (config.catppuccin) sources;
+
+  cfg = config.programs.fuzzel.catppuccin;
+  enable = cfg.enable && config.programs.fuzzel.enable;
+in
+{
+  options.programs.fuzzel.catppuccin = lib.ctp.mkCatppuccinOpt "fuzzel";
+
+  config = lib.mkIf enable {
+    xdg.configFile."fuzzel/fuzzel.ini".source = "${sources.fuzzel}/themes/${cfg.flavor}.ini";
+  };
+}

--- a/modules/home-manager/fuzzel.nix
+++ b/modules/home-manager/fuzzel.nix
@@ -7,7 +7,9 @@ let
   palette = (lib.importJSON "${sources.palette}/palette.json").${cfg.flavor}.colors;
 in
 {
-  options.programs.fuzzel.catppuccin = lib.ctp.mkCatppuccinOpt "fuzzel";
+  options.programs.fuzzel.catppuccin = lib.ctp.mkCatppuccinOpt "fuzzel" // {
+    accent = lib.ctp.mkAccentOpt "fuzzel";
+  };
 
   config.programs.fuzzel.settings.colors = lib.mkIf enable {
     background = palette.base.hex + "dd";
@@ -16,6 +18,6 @@ in
     selection = palette.surface2.hex + "ff";
     selection-match = palette.red.hex + "ff";
     selection-text = palette.text.hex + "ff";
-    border = palette."${cfg.accent}".hex + "ff";
+    border = palette.${cfg.accent}.hex + "ff";
   };
 }

--- a/modules/home-manager/fuzzel.nix
+++ b/modules/home-manager/fuzzel.nix
@@ -11,11 +11,11 @@ in
 
   config.programs.fuzzel.settings.colors = lib.mkIf enable {
     background = palette.base.hex + "dd";
-    text = palette.cfg.text.hex + "ff";
+    text = palette.text.hex + "ff";
     match = palette.red.hex + "ff";
-    selection = palette.cfg.surface2.hex + "ff";
+    selection = palette.surface2.hex + "ff";
     selection-match = palette.red.hex + "ff";
     selection-text = palette.text.hex + "ff";
-    border = palette.${cfg.accent}.hex + "ff";
+    border = palette."${cfg.accent}".hex + "ff";
   };
 }

--- a/modules/home-manager/fuzzel.nix
+++ b/modules/home-manager/fuzzel.nix
@@ -14,8 +14,8 @@ in
     text = palette."${cfg.text}".hex + "ff";
     match = palette."${cfg.red}".hex + "ff";
     selection = palette."${cfg.surface2}".hex + "ff";
-    selection-match = match;
-    selection-text = text;
+    selection-match = palette."${cfg.red}".hex + "ff";
+    selection-text = palette."${cfg.text}".hex + "ff";
     border = palette."${cfg.accent}".hex + "ff";
   };
 }

--- a/modules/home-manager/fuzzel.nix
+++ b/modules/home-manager/fuzzel.nix
@@ -4,11 +4,18 @@ let
 
   cfg = config.programs.fuzzel.catppuccin;
   enable = cfg.enable && config.programs.fuzzel.enable;
+  palette = (lib.importJSON "${sources.palette}/palette.json").${cfg.flavor}.colors;
 in
 {
   options.programs.fuzzel.catppuccin = lib.ctp.mkCatppuccinOpt "fuzzel";
 
-  config = lib.mkIf enable {
-    xdg.configFile."fuzzel/fuzzel.ini".source = "${sources.fuzzel}/themes/${cfg.flavor}.ini";
+  config.programs.fuzzel.settings.colors = lib.mkIf enable {
+    background = palette."${cfg.base}".hex + "dd";
+    text = palette."${cfg.text}".hex + "ff";
+    match = palette."${cfg.red}".hex + "ff";
+    selection = palette."${cfg.surface2}".hex + "ff";
+    selection-match = match;
+    selection-text = text;
+    border = palette."${cfg.accent}".hex + "ff";
   };
 }

--- a/modules/home-manager/fuzzel.nix
+++ b/modules/home-manager/fuzzel.nix
@@ -10,12 +10,12 @@ in
   options.programs.fuzzel.catppuccin = lib.ctp.mkCatppuccinOpt "fuzzel";
 
   config.programs.fuzzel.settings.colors = lib.mkIf enable {
-    background = palette."${cfg.base}".hex + "dd";
-    text = palette."${cfg.text}".hex + "ff";
-    match = palette."${cfg.red}".hex + "ff";
-    selection = palette."${cfg.surface2}".hex + "ff";
-    selection-match = palette."${cfg.red}".hex + "ff";
-    selection-text = palette."${cfg.text}".hex + "ff";
-    border = palette."${cfg.accent}".hex + "ff";
+    background = palette.base.hex + "dd";
+    text = palette.cfg.text.hex + "ff";
+    match = palette.red.hex + "ff";
+    selection = palette.cfg.surface2.hex + "ff";
+    selection-match = palette.red.hex + "ff";
+    selection-text = palette.text.hex + "ff";
+    border = palette.${cfg.accent}.hex + "ff";
   };
 }

--- a/test.nix
+++ b/test.nix
@@ -84,6 +84,7 @@ testers.runNixOSTest {
           cava = enable;
           fish = enable;
           foot = enable;
+          fuzzel = enable;
           fzf = enable;
           gh-dash = enable;
           git = enable // {


### PR DESCRIPTION
Added support for fuzzel.
Used ```xdg.configFile```, maybe there is a way to convert it to ```programs.fuzzel.settings.colors```.