### PR TITLE
fix(nixos/sddm): use the kde sddm package

### DIFF
--- a/modules/nixos/sddm.nix
+++ b/modules/nixos/sddm.nix
@@ -40,10 +40,32 @@ in
       default = true;
       description = "Add an additional background layer to the login panel";
     };
+
+    assertQt6Sddm =
+      lib.mkEnableOption ''
+        checking if `services.displayManager.sddm.package` is the Qt 6 version.
+
+        This is to ensure the theme is applied properly, but may have false positives in the case of overridden packages for example
+      ''
+      // {
+        default = true;
+      };
   };
 
   config = mkIf enable {
+    assertions = lib.optional cfg.assertQt6Sddm {
+      assertion = config.services.displayManager.sddm.package == pkgs.kdePackages.sddm;
+      message = ''
+        Only the Qt 6 version of SDDM is supported by this port!
+
+        In most cases this can be resolved by setting `services.displayManager.sddm.package`
+        to `pkgs.kdePackages.sddm`. If you know what you're doing and wish to disable this check,
+        please set `services.displayManager.sddm.catppuccin.assertQt6Sddm` to `false`
+      '';
+    };
+
     services.displayManager.sddm.theme = "catppuccin-${cfg.flavor}";
+
     environment.systemPackages = [
       (pkgs.catppuccin-sddm.override {
         inherit (cfg)

--- a/test.nix
+++ b/test.nix
@@ -29,7 +29,7 @@ testers.runNixOSTest {
   name = "module-test";
 
   nodes.machine =
-    { lib, ... }:
+    { lib, pkgs, ... }:
     {
       imports = [
         home-manager.nixosModules.default
@@ -43,7 +43,9 @@ testers.runNixOSTest {
       };
 
       services = {
-        displayManager.sddm = enable;
+        displayManager.sddm = enable // {
+          package = pkgs.kdePackages.sddm; # our module/the upstream port requires the qt6 version
+        };
         xserver.enable = true; # required for sddm
       };
 


### PR DESCRIPTION
This resolves the error where the theme doesn't work if plasma6 isn't enabled. by default the packge is qt5 sddm, but catppuccin/sddm uses qt6.