### PR TITLE
fix(home-manager): use correct theme name

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -72,15 +72,10 @@ in
     gtk = {
       theme =
         let
-          flavorUpper = ctp.mkUpper cfg.flavor;
-          accentUpper = ctp.mkUpper cfg.accent;
-          sizeUpper = ctp.mkUpper cfg.size;
-
-          # use the light gtk theme for latte
-          gtkTheme = if cfg.flavor == "latte" then "Light" else "Dark";
+          gtkTweaks = lib.concatStringsSep "," cfg.tweaks;
         in
         {
-          name = "Catppuccin-${flavorUpper}-${sizeUpper}-${accentUpper}-${gtkTheme}";
+          name = "catppuccin-${cfg.flavor}-${cfg.accent}-${cfg.size}+${gtkTweaks}";
           package = pkgs.catppuccin-gtk.override {
             inherit (cfg) size tweaks;
             accents = [ cfg.accent ];


### PR DESCRIPTION
## Summary
The theme name does not correctly match the one from catppuccin-gtk which should be `catppuccin-${FLAVOR}-${ACCENT}-${SIZE}+${TWEAKS}` as the [Usage docs](https://github.com/catppuccin/gtk/blob/23b52b5b9cde1e11c07315e79a55804d2ac77e3a/docs/USAGE.md#manual-installation) specify.

## Changes
- Name is all lower case now
- Order changed from `flavor-size-accent-gtkTheme` to `flavor-accent-size+tweaks`