### PR TITLE
fix(home-manager): assert `qt.style.name` for kvantum theme

### DIFF
--- a/modules/home-manager/kvantum.nix
+++ b/modules/home-manager/kvantum.nix
@@ -6,13 +6,8 @@
 }:
 let
   cfg = config.qt.style.catppuccin;
-  enable =
-    cfg.enable
-    && config.qt.enable
-    && lib.elem config.qt.style.name [
-      "kvantum"
-      "Kvantum"
-    ];
+  enable = cfg.enable && config.qt.enable;
+
   flavorCapitalized = lib.ctp.mkUpper cfg.flavor;
   accentCapitalized = lib.ctp.mkUpper cfg.accent;
   theme = pkgs.catppuccin-kvantum.override {
@@ -35,13 +30,25 @@ in
     };
   };
 
-  config.xdg.configFile = lib.mkIf enable {
-    "Kvantum/${themeName}".source = "${theme}/share/Kvantum/${themeName}";
-    "Kvantum/kvantum.kvconfig" = lib.mkIf cfg.apply {
-      text = ''
-        [General]
-        theme=${themeName}
-      '';
+  config = lib.mkIf enable {
+    assertions = [
+      {
+        assertion = lib.elem config.qt.style.name [
+          "kvantum"
+          "Kvantum"
+        ];
+        message = ''`qt.style.name` must be `"kvantum"` to use `qt.style.catppuccin`'';
+      }
+    ];
+
+    xdg.configFile = {
+      "Kvantum/${themeName}".source = "${theme}/share/Kvantum/${themeName}";
+      "Kvantum/kvantum.kvconfig" = lib.mkIf cfg.apply {
+        text = ''
+          [General]
+          theme=${themeName}
+        '';
+      };
     };
   };
 }


### PR DESCRIPTION
while having `qt.enable` be a prerequisite for this option applying
makes sense, the requirement on a specific `style.name` is not. this
make it more clear by moving that check to an assertion rather than an
internal comparison
