### PR TITLE
fix(home-manager/gtk): replace `normal` tweak with `default`

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -121,7 +121,9 @@ in
     (mkIf enable {
       gtk.theme =
         let
-          gtkTweaks = concatStringsSep "," cfg.tweaks;
+          gtkTweaks = concatStringsSep "," (
+            map (tweak: { normal = "default"; }.${tweak} or tweak) cfg.tweaks
+          );
         in
         {
           name = "catppuccin-${cfg.flavor}-${cfg.accent}-${cfg.size}+${gtkTweaks}";


### PR DESCRIPTION
Seeing as this does not exist and should be default we should remove the "normal" and replace it with default
![image](https://github.com/catppuccin/nix/assets/71222764/65debe03-5b68-4963-9ed8-56ddf2c24a50)
