### PR TITLE
fix(home-manager): GTK module bad linking from tweak default setting

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -122,7 +122,7 @@ in
       gtk.theme =
         let
           gtkTweaks = concatStringsSep "," (
-            map (tweak: { normal = "default"; }.${tweak} or tweak) cfg.tweaks
+            map (tweak: { normal = "normal"; }.${tweak} or tweak) cfg.tweaks
           );
         in
         {

--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -121,9 +121,7 @@ in
     (mkIf enable {
       gtk.theme =
         let
-          gtkTweaks = concatStringsSep "," (
-            map (tweak: { normal = "normal"; }.${tweak} or tweak) cfg.tweaks
-          );
+          gtkTweaks = concatStringsSep "," cfg.tweaks;
         in
         {
           name = "catppuccin-${cfg.flavor}-${cfg.accent}-${cfg.size}+${gtkTweaks}";


### PR DESCRIPTION
This PR fix this issue: https://github.com/catppuccin/nix/issues/269

GTK module does not correctly define the configuration path due to an error in the mapping of the default option for tweak configuration.