### PR TITLE
Revert "fix(home-manager/gtk): replace `normal` tweak with `default`"

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -121,9 +121,7 @@ in
     (mkIf enable {
       gtk.theme =
         let
-          gtkTweaks = concatStringsSep "," (
-            map (tweak: { normal = "default"; }.${tweak} or tweak) cfg.tweaks
-          );
+          gtkTweaks = concatStringsSep "," cfg.tweaks;
         in
         {
           name = "catppuccin-${cfg.flavor}-${cfg.accent}-${cfg.size}+${gtkTweaks}";


### PR DESCRIPTION
Reverts catppuccin/nix#261

as we said we would do here too https://github.com/catppuccin/nix/pull/270