### PR TITLE
fix(home-manager/cursors): automatically enable cursor for gtk and x11

### DIFF
--- a/modules/home-manager/cursor.nix
+++ b/modules/home-manager/cursor.nix
@@ -31,5 +31,8 @@ in
   config.home.pointerCursor = mkIf cfg.enable {
     name = "catppuccin-${cfg.flavor}-${cfg.accent}-cursors";
     package = pkgs.catppuccin-cursors.${cfg.flavor + ctp.mkUpper cfg.accent};
+
+    gtk.enable = true;
+    x11.enable = true;
   };
 }


### PR DESCRIPTION
Otherwise, `home.pointerCursor` is useless I suppose

EDIT: Not entirely useless (see https://github.com/nix-community/home-manager/blob/0a30138c694ab3b048ac300794c2eb599dc40266/modules/config/home-cursor.nix#L165), but still it didn't work for me on GNOME