### PR TITLE
feat(home-manager): add support for spotify-player

### DIFF
--- a/.sources/sources.json
+++ b/.sources/sources.json
@@ -360,6 +360,18 @@
       "url": "https://github.com/catppuccin/skim/archive/d39304b5f84721788b19bc40aebcfd7720208d8a.tar.gz",
       "hash": "1b6cd1wfkprrn7imgf1w1f9a6iqy3bql2ansy7l0k44ps1gwrvxq"
     },
+    "spotify-player": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "catppuccin",
+        "repo": "spotify-player"
+      },
+      "branch": "main",
+      "revision": "1647789ce66e2411b39b2388681a8bee60bd57b0",
+      "url": "https://github.com/catppuccin/spotify-player/archive/1647789ce66e2411b39b2388681a8bee60bd57b0.tar.gz",
+      "hash": "0plryk71vs4kmd7nng3xxai532nr66acvkahph965blwa241xclf"
+    },
     "starship": {
       "type": "Git",
       "repository": {

--- a/.sources/sources.json
+++ b/.sources/sources.json
@@ -368,9 +368,9 @@
         "repo": "spotify-player"
       },
       "branch": "main",
-      "revision": "1647789ce66e2411b39b2388681a8bee60bd57b0",
-      "url": "https://github.com/catppuccin/spotify-player/archive/1647789ce66e2411b39b2388681a8bee60bd57b0.tar.gz",
-      "hash": "0plryk71vs4kmd7nng3xxai532nr66acvkahph965blwa241xclf"
+      "revision": "34b3d23806770185b72466d777853c73454b85a6",
+      "url": "https://github.com/catppuccin/spotify-player/archive/34b3d23806770185b72466d777853c73454b85a6.tar.gz",
+      "hash": "15cz4x432681zwik8dwmjljj628v540c1fz1m4v6nvvw63bdzsbr"
     },
     "starship": {
       "type": "Git",

--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -33,6 +33,7 @@
   ./rio.nix
   ./rofi.nix
   ./skim.nix
+  ./spotify-player.nix
   ./starship.nix
   ./swaylock.nix
   ./sway.nix

--- a/modules/home-manager/spotify-player.nix
+++ b/modules/home-manager/spotify-player.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }:
+let
+  inherit (config.catppuccin) sources;
+  cfg = config.programs.spotify-player.catppuccin;
+  enable = cfg.enable && config.programs.spotify-player.enable;
+in
+{
+  options.programs.spotify-player.catppuccin = lib.ctp.mkCatppuccinOpt { name = "spotify-player"; };
+
+  config = lib.mkIf enable {
+    programs.spotify-player = {
+      settings.theme = "Catppuccin-${cfg.flavor}";
+      themes = (lib.importTOML "${sources.spotify-player}/theme.toml").themes;
+    };
+  };
+}

--- a/modules/home-manager/spotify-player.nix
+++ b/modules/home-manager/spotify-player.nix
@@ -10,7 +10,7 @@ in
   config = lib.mkIf enable {
     programs.spotify-player = {
       settings.theme = "Catppuccin-${cfg.flavor}";
-      themes = (lib.importTOML "${sources.spotify-player}/theme.toml").themes;
+      inherit (lib.importTOML "${sources.spotify-player}/theme.toml") themes;
     };
   };
 }

--- a/tests/home.nix
+++ b/tests/home.nix
@@ -47,6 +47,7 @@
     rio.enable = true;
     rofi.enable = true;
     skim.enable = true;
+    spotify-player.enable = true;
     starship.enable = true;
     swaylock.enable = true;
     tmux.enable = true;


### PR DESCRIPTION
I have an issue with the theme:
The `playback_metadata` component has the same color as the background and is therefore not legible.
But this should be fixed in the [catppuccin repo](https://github.com/catppuccin/spotify-player), right?