### PR TITLE
fix(home-manager/zathura): avoid IFD

### DIFF
--- a/modules/home-manager/zathura.nix
+++ b/modules/home-manager/zathura.nix
@@ -1,23 +1,13 @@
-{
-  config,
-  pkgs,
-  lib,
-  ...
-}:
+{ config, lib, ... }:
 let
   inherit (config.catppuccin) sources;
   cfg = config.programs.zathura.catppuccin;
   enable = cfg.enable && config.programs.zathura.enable;
-  themeFile = sources.zathura + "/src/catppuccin-${cfg.flavor}";
 in
 {
   options.programs.zathura.catppuccin = lib.ctp.mkCatppuccinOpt { name = "zathura"; };
 
-  config.programs.zathura.options = lib.mkIf enable (
-    lib.ctp.fromINI (
-      pkgs.runCommand "catppuccin-zathura-theme" { } ''
-        ${pkgs.gawk}/bin/awk '/.+/ { printf "%s=%s\n", $2, $3 }' ${themeFile} > $out
-      ''
-    )
-  );
+  config.programs.zathura.extraConfig = lib.mkIf enable ''
+    include ${sources.zathura + "/src/catppuccin-${cfg.flavor}"}
+  '';
 }


### PR DESCRIPTION
Uses zathura's `include` command to include the theme rather than importing the theme file into nix.