### PR TITLE
fix(home-manager/foot): avoid IFD

### DIFF
--- a/modules/home-manager/foot.nix
+++ b/modules/home-manager/foot.nix
@@ -4,10 +4,11 @@ let
 
   cfg = config.programs.foot.catppuccin;
   enable = cfg.enable && config.programs.foot.enable;
-  theme = lib.ctp.fromINI (sources.foot + "/themes/catppuccin-${cfg.flavor}.ini");
 in
 {
   options.programs.foot.catppuccin = lib.ctp.mkCatppuccinOpt { name = "foot"; };
 
-  config.programs.foot = lib.mkIf enable { settings = theme; };
+  config.programs.foot = lib.mkIf enable {
+    settings.main.include = sources.foot + "/themes/catppuccin-${cfg.flavor}.ini";
+  };
 }


### PR DESCRIPTION
Use foot's `include` option to import the theme rather than importing the theme into nix.