### PR TITLE
fix(home-manager/tofi): avoid IFD

### DIFF
--- a/modules/home-manager/tofi.nix
+++ b/modules/home-manager/tofi.nix
@@ -8,6 +8,6 @@ in
   options.programs.tofi.catppuccin = lib.ctp.mkCatppuccinOpt { name = "tofi"; };
 
   config.programs.tofi = lib.mkIf enable {
-    settings = lib.ctp.fromINI (sources.tofi + "/themes/catppuccin-${cfg.flavor}");
+    settings.include = sources.tofi + "/themes/catppuccin-${cfg.flavor}";
   };
 }


### PR DESCRIPTION
Use tofi's include option to import the theme rather than importing it into nix.