### PR TITLE
fix(home-manager/dunst): avoid IFD

### DIFF
--- a/modules/home-manager/dunst.nix
+++ b/modules/home-manager/dunst.nix
@@ -5,9 +5,22 @@ let
   enable = cfg.enable && config.services.dunst.enable;
 in
 {
-  options.services.dunst.catppuccin = lib.ctp.mkCatppuccinOpt { name = "dunst"; };
+  options.services.dunst.catppuccin = lib.ctp.mkCatppuccinOpt { name = "dunst"; } // {
+    prefix = lib.mkOption {
+      type = lib.types.str;
+      default = "00";
+      description = "Prefix to use for the dunst drop-in file";
+    };
+  };
 
-  config.services.dunst = lib.mkIf enable {
-    settings = lib.ctp.fromINI (sources.dunst + "/themes/${cfg.flavor}.conf");
+  # Dunst currently has no "include" functionality, but has "drop-ins"
+  # Unfortunately, this may cause inconvenience as it overrides ~/.config/dunst/dunstrc
+  # but it can be overridden by another drop-in.
+  config.xdg.configFile = lib.mkIf enable {
+    # Using a prefix like this is necessary because drop-ins' precedence depends on lexical order
+    # such that later drop-ins override earlier ones
+    # This way, users have better control over precedence
+    "dunst/dunstrc.d/${cfg.prefix}-catppuccin.conf".source =
+      sources.dunst + "/themes/${cfg.flavor}.conf";
   };
 }


### PR DESCRIPTION
Uses dunst's drop-in feature to set the theme rather than importing it into nix.

This approach has the drawback that theme settings are now potentially slightly more inconvenient to override. The theme drop-in overrides settings from `dunstrc`, but it can itself be overridden by another drop-in that is after it in lexical order.

I added a `prefix` option to make it more convenient to have the catppuccin drop-in appear in a certain spot in lexical order if the user has multiple drop-ins they wish to use with dunst.

Currently blocked on https://github.com/nix-community/home-manager/pull/5710