### PR TITLE
fix(home-manager/mpv): avoid IFD

### DIFF
--- a/.sources/sources.json
+++ b/.sources/sources.json
@@ -260,9 +260,9 @@
         "repo": "mpv"
       },
       "branch": "main",
-      "revision": "da9199f55b42f9158371f31a7e34d88d1d7c7145",
-      "url": "https://github.com/catppuccin/mpv/archive/da9199f55b42f9158371f31a7e34d88d1d7c7145.tar.gz",
-      "hash": "1zwzplbn0a043gxl1q239mbb824qm5jl965qyb6rfg66x3ws5wi8"
+      "revision": "7b93fb0febd0490a8ccfe3077ab7741a9b4ef44a",
+      "url": "https://github.com/catppuccin/mpv/archive/7b93fb0febd0490a8ccfe3077ab7741a9b4ef44a.tar.gz",
+      "hash": "1wzahqxqrblalkcxi4ll05vi5rhmsm3z4mk7d96rfka2c38wc5wj"
     },
     "newsboat": {
       "type": "Git",

--- a/modules/home-manager/mpv.nix
+++ b/modules/home-manager/mpv.nix
@@ -4,20 +4,13 @@ let
   inherit (lib) ctp mkIf;
   cfg = config.programs.mpv.catppuccin;
   enable = cfg.enable && config.programs.mpv.enable;
-  themeDir = sources.mpv + "/themes/${cfg.flavor}/${cfg.accent}";
-  uoscDir = sources.mpv + "/uosc/themes/${cfg.flavor}/${cfg.accent}";
 in
 {
   options.programs.mpv.catppuccin = ctp.mkCatppuccinOpt { name = "mpv"; } // {
     accent = ctp.mkAccentOpt "mpv";
   };
 
-  # Note that the theme is defined across multiple files
   config.programs.mpv = mkIf enable {
-    config = ctp.fromINI (themeDir + "/mpv.conf");
-    scriptOpts = {
-      stats = ctp.fromINI (themeDir + "/script-opts/stats.conf");
-      uosc = ctp.fromINI (uoscDir + "/script-opts/uosc.conf");
-    };
+    config.include = sources.mpv + "/themes/${cfg.flavor}/${cfg.accent}.conf";
   };
 }


### PR DESCRIPTION
Use mpv's `include` option to import the theme rather than importing it into nix.

I also had to update the mpv port because this relies on a recent change that puts all the settings in a single file because script-opts files cannot include other files, but their options can be set with the `script-opts` option in `mpv.conf`