### PR TITLE
fix(home-manager/k9s): support darwin without XDG

### DIFF
--- a/modules/home-manager/k9s.nix
+++ b/modules/home-manager/k9s.nix
@@ -1,22 +1,32 @@
-{ config, lib, ... }:
-let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
   inherit (config.catppuccin) sources;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
   cfg = config.programs.k9s.catppuccin;
   enable = cfg.enable && config.programs.k9s.enable;
 
   themeName = "catppuccin-${cfg.flavor}" + lib.optionalString cfg.transparent "-transparent";
   themeFile = "${themeName}.yaml";
-  themePath = "/skins/${themeFile}";
+  configDirectory =
+    if (isDarwin && !config.xdg.enable)
+    then "/Library/Application Support/k9s"
+    else "k9s";
+  themePath = "${configDirectory}/skins/${themeFile}";
   theme = sources.k9s + "/dist/${themeFile}";
-in
-{
-  options.programs.k9s.catppuccin = lib.ctp.mkCatppuccinOpt { name = "k9s"; } // {
-    transparent = lib.mkEnableOption "transparent version of flavor";
-  };
+in {
+  options.programs.k9s.catppuccin =
+    lib.ctp.mkCatppuccinOpt {name = "k9s";}
+    // {
+      transparent = lib.mkEnableOption "transparent version of flavor";
+    };
 
   config = lib.mkIf enable {
-    xdg.configFile."k9s${themePath}".source = theme;
+    xdg.configFile."${themePath}".source = theme;
 
     programs.k9s.settings.k9s.ui.skin = themeName;
   };

--- a/modules/home-manager/k9s.nix
+++ b/modules/home-manager/k9s.nix
@@ -3,31 +3,32 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   inherit (config.catppuccin) sources;
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
   cfg = config.programs.k9s.catppuccin;
   enable = cfg.enable && config.programs.k9s.enable;
 
+  # NOTE: On MacOS specifically, k9s expects its configuration to be in
+  # `~/Library/Application Support` when not using XDG
+  enableXdgConfig = !pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable;
+
   themeName = "catppuccin-${cfg.flavor}" + lib.optionalString cfg.transparent "-transparent";
   themeFile = "${themeName}.yaml";
-  configDirectory =
-    if (isDarwin && !config.xdg.enable)
-    then "/Library/Application Support/k9s"
-    else "k9s";
-  themePath = "${configDirectory}/skins/${themeFile}";
+  themePath = "k9s/skins/${themeFile}";
   theme = sources.k9s + "/dist/${themeFile}";
-in {
-  options.programs.k9s.catppuccin =
-    lib.ctp.mkCatppuccinOpt {name = "k9s";}
-    // {
-      transparent = lib.mkEnableOption "transparent version of flavor";
-    };
-
-  config = lib.mkIf enable {
-    xdg.configFile."${themePath}".source = theme;
-
-    programs.k9s.settings.k9s.ui.skin = themeName;
+in
+{
+  options.programs.k9s.catppuccin = lib.ctp.mkCatppuccinOpt { name = "k9s"; } // {
+    transparent = lib.mkEnableOption "transparent version of flavor";
   };
+
+  config = lib.mkIf enable lib.mkMerge [
+    (lib.mkIf (!enableXdgConfig) {
+      home.file."Library/Application Support/${themePath}".source = theme;
+    })
+    (lib.mkIf enableXdgConfig { xdg.configFile.${themePath}.source = theme; })
+    { programs.k9s.settings.k9s.ui.skin = themeName; }
+  ];
 }

--- a/modules/home-manager/k9s.nix
+++ b/modules/home-manager/k9s.nix
@@ -24,11 +24,11 @@ in
     transparent = lib.mkEnableOption "transparent version of flavor";
   };
 
-  config = lib.mkIf enable lib.mkMerge [
+  config = lib.mkIf enable (lib.mkMerge [
     (lib.mkIf (!enableXdgConfig) {
       home.file."Library/Application Support/${themePath}".source = theme;
     })
     (lib.mkIf enableXdgConfig { xdg.configFile.${themePath}.source = theme; })
     { programs.k9s.settings.k9s.ui.skin = themeName; }
-  ];
+  ]);
 }


### PR DESCRIPTION
k9s expects configuration files on OS X to live in `~/Library/Application Support/k9s` instead of `~/.config.k9s`. This commit handles the case where the module is built for a darwin system with xdg disabled.

See: https://github.com/catppuccin/nix/issues/310