### PR TITLE
fix(home-manager/lazygit): support darwin without XDG

### DIFF
--- a/modules/home-manager/lazygit.nix
+++ b/modules/home-manager/lazygit.nix
@@ -1,17 +1,28 @@
-{ config, lib, ... }:
-let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
   inherit (lib) ctp;
   inherit (config.catppuccin) sources;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
   cfg = config.programs.lazygit.catppuccin;
   enable = cfg.enable && config.programs.lazygit.enable;
-in
-{
-  options.programs.lazygit.catppuccin = lib.ctp.mkCatppuccinOpt { name = "lazygit"; } // {
-    accent = ctp.mkAccentOpt "lazygit";
-  };
+  configDirectory =
+    if (isDarwin && !config.xdg.enable)
+    then "${config.home.homeDirectory}/Library/Application Support/lazygit"
+    else "${config.xdg.configHome}/lazygit";
+in {
+  options.programs.lazygit.catppuccin =
+    lib.ctp.mkCatppuccinOpt {name = "lazygit";}
+    // {
+      accent = ctp.mkAccentOpt "lazygit";
+    };
 
   config.home.sessionVariables = lib.mkIf enable {
     # Ensure that the default config file is still sourced
-    LG_CONFIG_FILE = "${sources.lazygit}/themes-mergable/${cfg.flavor}/${cfg.accent}.yml,${config.xdg.configHome}/lazygit/config.yml";
+    LG_CONFIG_FILE = "${sources.lazygit}/themes-mergable/${cfg.flavor}/${cfg.accent}.yml,${configDirectory}/config.yml";
   };
 }

--- a/modules/home-manager/lazygit.nix
+++ b/modules/home-manager/lazygit.nix
@@ -3,26 +3,32 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   inherit (lib) ctp;
   inherit (config.catppuccin) sources;
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
   cfg = config.programs.lazygit.catppuccin;
   enable = cfg.enable && config.programs.lazygit.enable;
+
+  # NOTE: On MacOS specifically, k9s expects its configuration to be in
+  # `~/Library/Application Support` when not using XDG
+  enableXdgConfig = !pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable;
+
   configDirectory =
-    if (isDarwin && !config.xdg.enable)
-    then "${config.home.homeDirectory}/Library/Application Support/lazygit"
-    else "${config.xdg.configHome}/lazygit";
-in {
-  options.programs.lazygit.catppuccin =
-    lib.ctp.mkCatppuccinOpt {name = "lazygit";}
-    // {
-      accent = ctp.mkAccentOpt "lazygit";
-    };
+    if enableXdgConfig then
+      "${config.home.homeDirectory}/Library/Application Support"
+    else
+      "${config.xdg.configHome}";
+  configFile = "${configDirectory}/lazygit/config.yml";
+in
+{
+  options.programs.lazygit.catppuccin = lib.ctp.mkCatppuccinOpt { name = "lazygit"; } // {
+    accent = ctp.mkAccentOpt "lazygit";
+  };
 
   config.home.sessionVariables = lib.mkIf enable {
     # Ensure that the default config file is still sourced
-    LG_CONFIG_FILE = "${sources.lazygit}/themes-mergable/${cfg.flavor}/${cfg.accent}.yml,${configDirectory}/config.yml";
+    LG_CONFIG_FILE = "${sources.lazygit}/themes-mergable/${cfg.flavor}/${cfg.accent}.yml,${configFile}";
   };
 }

--- a/modules/home-manager/lazygit.nix
+++ b/modules/home-manager/lazygit.nix
@@ -17,9 +17,9 @@ let
 
   configDirectory =
     if enableXdgConfig then
-      "${config.home.homeDirectory}/Library/Application Support"
+      config.xdg.configHome
     else
-      "${config.xdg.configHome}";
+      "${config.home.homeDirectory}/Library/Application Support";
   configFile = "${configDirectory}/lazygit/config.yml";
 in
 {


### PR DESCRIPTION
Lazygit would fail to load becase the wrong path was being generated to the configuration file on darwin systems when XDG wasn't enabled.

Fixes #312 