### PR TITLE
fix(tmux): follow upstream spelling change

### DIFF
--- a/modules/home-manager/tmux.nix
+++ b/modules/home-manager/tmux.nix
@@ -40,7 +40,7 @@ in
       inherit plugin;
       extraConfig = concatStrings [
         ''
-          set -g @catppuccin_flavour '${cfg.flavor}'
+          set -g @catppuccin_flavor '${cfg.flavor}'
         ''
         cfg.extraConfig
       ];


### PR DESCRIPTION
[catppuccin/tmux](https://github.com/catppuccin/tmux) recently switched the spelling of flavour to flavor in https://github.com/catppuccin/tmux/pull/277