### PR TITLE
fix: add enable option to fuzzel

### DIFF
--- a/modules/home-manager/fuzzel.nix
+++ b/modules/home-manager/fuzzel.nix
@@ -2,13 +2,14 @@
 let
   inherit (config.catppuccin) sources;
   cfg = config.programs.fuzzel.catppuccin;
+  enable = cfg.enable && config.programs.fuzzel.enable;
 in
 {
   options.programs.fuzzel.catppuccin = lib.ctp.mkCatppuccinOpt { name = "fuzzel"; } // {
     accent = lib.ctp.mkAccentOpt "fuzzel";
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf enable {
     programs.fuzzel.settings.main.include = sources.fuzzel + "/themes/${cfg.flavor}/${cfg.accent}.ini";
   };
 }


### PR DESCRIPTION
It only checked if catppuccin was enabled globally