### PR TITLE
feat(mako): add accent color support

### DIFF
--- a/.sources/sources.json
+++ b/.sources/sources.json
@@ -248,9 +248,9 @@
         "repo": "mako"
       },
       "branch": "main",
-      "revision": "33cb59ce8483725e2dd3e818aecbf0bab259bde8",
-      "url": "https://github.com/catppuccin/mako/archive/33cb59ce8483725e2dd3e818aecbf0bab259bde8.tar.gz",
-      "hash": "1hy1k5dm8q75i9bqffmg8z4k0qkg9291k73vhpp0msn7bivb1aba"
+      "revision": "92844f144e72f2dc8727879ec141ffdacf3ff6a1",
+      "url": "https://github.com/catppuccin/mako/archive/92844f144e72f2dc8727879ec141ffdacf3ff6a1.tar.gz",
+      "hash": "0nz5x66bv0nhmgh2slw647j69x7pqcw0cyclkpv3bq6c5bw9j24f"
     },
     "micro": {
       "type": "Git",

--- a/modules/home-manager/mako.nix
+++ b/modules/home-manager/mako.nix
@@ -8,7 +8,7 @@ let
   inherit (config.catppuccin) sources;
   cfg = config.services.mako.catppuccin;
   enable = cfg.enable && config.services.mako.enable;
-  theme = lib.ctp.fromINI (sources.mako + "/themes/${cfg.flavor}");
+  theme = lib.ctp.fromINI (sources.mako + "/themes/${cfg.flavor}/${cfg.accent}");
 
   # Settings that need to be extracted and put in extraConfig
   extraConfigAttrs = lib.attrsets.getAttrs [ "urgency=high" ] theme;

--- a/modules/home-manager/mako.nix
+++ b/modules/home-manager/mako.nix
@@ -14,7 +14,9 @@ let
   extraConfigAttrs = lib.attrsets.getAttrs [ "urgency=high" ] theme;
 in
 {
-  options.services.mako.catppuccin = lib.ctp.mkCatppuccinOpt { name = "mako"; };
+  options.services.mako.catppuccin = lib.ctp.mkCatppuccinOpt { name = "mako"; } // {
+    accent = lib.ctp.mkAccentOpt "mako";
+  };
 
   # Will cause infinite recursion if config.services.mako is directly set as a whole
   config.services.mako = lib.mkIf enable {

--- a/modules/home-manager/mako.nix
+++ b/modules/home-manager/mako.nix
@@ -8,7 +8,7 @@ let
   inherit (config.catppuccin) sources;
   cfg = config.services.mako.catppuccin;
   enable = cfg.enable && config.services.mako.enable;
-  theme = lib.ctp.fromINI (sources.mako + "/themes/${cfg.flavor}/${cfg.accent}");
+  theme = lib.ctp.fromINI (sources.mako + "/themes/catppuccin-${cfg.flavor}/catppuccin-${cfg.flavor}-${cfg.accent}");
 
   # Settings that need to be extracted and put in extraConfig
   extraConfigAttrs = lib.attrsets.getAttrs [ "urgency=high" ] theme;


### PR DESCRIPTION
I created a pr in catppuccin/mako to add accent color support.
I don't know if it will get merged, but if it will, I can update the sources and it will be available here too.
If it doesn't, just ignore this pr.

This pr is also like a "reminder" to let you know that mako might "break" if the ipstream pr gets merged but this doesn't.