### PR TITLE
feat(home-manager): add support for freetube

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -10,6 +10,7 @@
   ./fcitx5.nix
   ./fish.nix
   ./foot.nix
+  ./freetube.nix
   ./fuzzel.nix
   ./fzf.nix
   ./gh-dash.nix

--- a/modules/home-manager/freetube.nix
+++ b/modules/home-manager/freetube.nix
@@ -1,0 +1,25 @@
+{ config, lib, ... }:
+let
+  inherit (config.programs.freetube.settings) baseTheme;
+  inherit (lib.ctp) mkAccentOpt mkUpper;
+  cfg = config.programs.freetube.catppuccin;
+  enable = cfg.enable && config.programs.freetube.enable;
+in
+{
+  options.programs.freetube.catppuccin = lib.ctp.mkCatppuccinOpt { name = "freetube"; } // {
+    accent = mkAccentOpt "FreeTube";
+    # FreeTube supports two accent colors
+    secondaryAccent = mkAccentOpt "FreeTube" // {
+      # Have the secondary accent default to FreeTube's main accent rather than the global Catppuccin accent
+      # This assumes most users would prefer both accent colors to be the same when only overriding the main one
+      default = cfg.accent;
+    };
+  };
+
+  config.programs.freetube.settings = lib.mkIf enable {
+    # NOTE: For some reason, baseTheme does not capitalize first letter, but the other settings do
+    baseTheme = "catppuccin${mkUpper cfg.flavor}";
+    mainColor = mkUpper "${baseTheme}${mkUpper cfg.accent}";
+    secColor = mkUpper "${baseTheme}${mkUpper cfg.secondaryAccent}";
+  };
+}

--- a/tests/home.nix
+++ b/tests/home.nix
@@ -24,6 +24,7 @@
     cava.enable = true;
     fish.enable = true;
     foot.enable = true;
+    freetube.enable = true;
     fuzzel.enable = true;
     fzf.enable = true;
     gh-dash.enable = true;


### PR DESCRIPTION
Adds support for theming FreeTube. The colors are built-in, so no new sources have been added.

Also, FreeTube supports two different accent colors, so I added a `secondaryAccent` option. I made it default to FreeTube's `accent` rather than the global `accent` setting because it seemed like it would be intuitive behavior to have them match if, say, only `accent` is overridden.