### PR TITLE
fix(home-manager/kitty): use new `themeFile` option on 24.11

### DIFF
--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726785354,
-        "narHash": "sha256-SLorVhoorZwjM1aS04bBX4fufEXIfkMdAGkj9bu2QAQ=",
+        "lastModified": 1726902823,
+        "narHash": "sha256-Gkc7pwTVLKj4HSvRt8tXNvosl8RS9hrBAEhOjAE0Tt4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1786e2afdbc48e9038f7cff585069736e1d0ed44",
+        "rev": "14929f7089268481d86b83ed31ffd88713dcd415",
         "type": "github"
       },
       "original": {

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -23,7 +23,6 @@
       cava.catppuccin.enable = false;
       gh-dash.catppuccin.enable = false;
       imv.catppuccin.enable = false;
-      kitty.catppuccin.enable = false; # IFD is introduced by home-manager
       swaylock.catppuccin.enable = false;
     };
   

--- a/modules/home-manager/kitty.nix
+++ b/modules/home-manager/kitty.nix
@@ -3,9 +3,13 @@ let
   inherit (lib) ctp;
   cfg = config.programs.kitty.catppuccin;
   enable = cfg.enable && config.programs.kitty.enable;
+
+  # TODO: Remove after 24.11 is stable
+  # https://github.com/nix-community/home-manager/pull/5750
+  attrName = if (lib.versionAtLeast ctp.getModuleRelease "24.11") then "themeFile" else "theme";
 in
 {
   options.programs.kitty.catppuccin = ctp.mkCatppuccinOpt { name = "kitty"; };
 
-  config.programs.kitty = lib.mkIf enable { theme = "Catppuccin-${ctp.mkUpper cfg.flavor}"; };
+  config = lib.mkIf enable { programs.kitty.${attrName} = "Catppuccin-${ctp.mkUpper cfg.flavor}"; };
 }


### PR DESCRIPTION
also removed kitty from the IFD section in the faq, as `themeFile` doesn't use IFD