### PR TITLE
docs: remove kitty from README ifd faq

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ For [standalone installations](https://nix-community.github.io/home-manager/inde
       cava.catppuccin.enable = false;
       gh-dash.catppuccin.enable = false;
       imv.catppuccin.enable = false;
-      kitty.catppuccin.enable = false; # IFD is introduced by home-manager
       swaylock.catppuccin.enable = false;
     };
   


### PR DESCRIPTION
Upstream removed the ifd in home-manger/kitty, #337 made the required changes and removed it from the ifd faq in docs/src/faq.md but not README.md.