### PR TITLE
fix(home-manager/hyprland): import accents from file

### DIFF
--- a/modules/home-manager/hyprland.nix
+++ b/modules/home-manager/hyprland.nix
@@ -18,9 +18,14 @@ in
     };
 
     wayland.windowManager.hyprland.settings = {
-      source = [ "${sources.hyprland}/themes/${cfg.flavor}.conf" ];
-      "$accent" = "\$${cfg.accent}";
-      "$accentAlpha" = "\$${cfg.accent}Alpha";
+      source = [
+        "${sources.hyprland}/themes/${cfg.flavor}.conf"
+        # Define accents in file to ensure they appear before user vars
+        (builtins.toFile "hyprland-${cfg.accent}-accent.conf" ''
+          $accent = ''$${cfg.accent}
+          $accentAlpha = ''$${cfg.accent}Alpha
+        '')
+      ];
     };
   };
 }

--- a/modules/home-manager/hyprlock.nix
+++ b/modules/home-manager/hyprlock.nix
@@ -11,9 +11,14 @@ in
 
   config = lib.mkIf enable {
     programs.hyprlock.settings = {
-      source = [ "${sources.hyprland}/themes/${cfg.flavor}.conf" ];
-      "$accent" = "\$${cfg.accent}";
-      "$accentAlpha" = "\$${cfg.accent}Alpha";
+      source = [
+        "${sources.hyprland}/themes/${cfg.flavor}.conf"
+        # Define accents in file to ensure they appear before user vars
+        (builtins.toFile "hyprland-${cfg.accent}-accent.conf" ''
+          $accent = ''$${cfg.accent}
+          $accentAlpha = ''$${cfg.accent}Alpha
+        '')
+      ];
     };
   };
 }


### PR DESCRIPTION
Ensure accents are defined before user vars
Partially reverts 512306ae
See https://github.com/catppuccin/nix/pull/299#discussion_r1706992419