### PR TITLE
fix(home-manager/kvantum): don't uppercase accents and flavors in override

### DIFF
--- a/modules/home-manager/kvantum.nix
+++ b/modules/home-manager/kvantum.nix
@@ -10,11 +10,22 @@ let
 
   flavorCapitalized = lib.ctp.mkUpper cfg.flavor;
   accentCapitalized = lib.ctp.mkUpper cfg.accent;
-  theme = pkgs.catppuccin-kvantum.override {
-    accent = accentCapitalized;
-    variant = flavorCapitalized;
-  };
-  themeName = "Catppuccin-${flavorCapitalized}-${accentCapitalized}";
+
+  theme = if (lib.versionAtLeast lib.ctp.getModuleRelease "24.11") then
+    pkgs.catppuccin-kvantum.override {
+      accent = cfg.accent;
+      variant = cfg.flavor;
+    }
+  else
+    pkgs.catppuccin-kvantum.override {
+      accent = accentCapitalized;
+      variant = flavorCapitalized;
+    };
+
+  themeName = if (lib.versionAtLeast lib.ctp.getModuleRelease "24.11") then
+    "catppuccin-${cfg.flavor}-${cfg.accent}"
+  else
+    "Catppuccin-${flavorCapitalized}-${accentCapitalized}";
 in
 {
   options.qt.style.catppuccin = lib.ctp.mkCatppuccinOpt { name = "Kvantum"; } // {


### PR DESCRIPTION
Fix for kvantum module, which uses an updated catppuccin-kvantum package that changed from uppercase enums to lowercase.

Closes #357