### PR TITLE
feat(home-manager): update yazi for accent support

### DIFF
--- a/.sources/sources.json
+++ b/.sources/sources.json
@@ -476,9 +476,9 @@
         "repo": "yazi"
       },
       "branch": "main",
-      "revision": "37dec9bf1f7e52e0d593c225827b9dbc71ce504c",
-      "url": "https://github.com/catppuccin/yazi/archive/37dec9bf1f7e52e0d593c225827b9dbc71ce504c.tar.gz",
-      "hash": "1dfakxd5fd1z17bf2l4a48wmal9pk9ybc0zxwnmvjaqj2gd3k6m0"
+      "revision": "54d868433a0c2f3e1651114136ea088eef72a4a7",
+      "url": "https://github.com/catppuccin/yazi/archive/54d868433a0c2f3e1651114136ea088eef72a4a7.tar.gz",
+      "hash": "08rml9np5qqvnqyrhhfj515mddfzqbxrxalscm5kswnj5mfx5ibl"
     },
     "zathura": {
       "type": "Git",

--- a/modules/home-manager/yazi.nix
+++ b/modules/home-manager/yazi.nix
@@ -6,10 +6,12 @@ let
   enable = cfg.enable && config.programs.yazi.enable;
 in
 {
-  options.programs.yazi.catppuccin = lib.ctp.mkCatppuccinOpt { name = "yazi"; };
+  options.programs.yazi.catppuccin = lib.ctp.mkCatppuccinOpt { name = "yazi"; } // {
+    accent = lib.ctp.mkAccentOpt "yazi";
+  };
 
   config = lib.mkIf enable {
-    programs.yazi.theme = lib.importTOML "${sources.yazi}/themes/${cfg.flavor}.toml";
+    programs.yazi.theme = lib.importTOML "${sources.yazi}/themes/${cfg.flavor}/catppuccin-${cfg.flavor}-${cfg.accent}.toml";
     xdg.configFile."yazi/Catppuccin-${cfg.flavor}.tmTheme".source = "${sources.bat}/themes/Catppuccin ${lib.ctp.mkUpper cfg.flavor}.tmTheme";
   };
 }


### PR DESCRIPTION
Updates the module to support the newly added accent variants (https://github.com/catppuccin/yazi/pull/12).