### PR TITLE
feat(home-manager): init wlogout module

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -43,6 +43,7 @@
   ./tofi.nix
   ./obs.nix
   ./waybar.nix
+  ./wlogout.nix
   ./yazi.nix
   ./zathura.nix
   ./zed-editor.nix

--- a/modules/home-manager/wlogout.nix
+++ b/modules/home-manager/wlogout.nix
@@ -1,0 +1,65 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+
+let
+  inherit (config.catppuccin) sources;
+
+  cfg = config.catppuccin.wlogout;
+in
+
+{
+  options.catppuccin.wlogout =
+    catppuccinLib.mkCatppuccinOption {
+      name = "wlogout";
+      accentSupport = true;
+    }
+    // {
+      iconStyle = lib.mkOption {
+        type = lib.types.enum [
+          "wlogout"
+          "wleave"
+        ];
+        description = "Icon style to set in ~/.config/wlogout/style.css";
+        default = "wlogout";
+        example = lib.literalExpression "wleave";
+      };
+      extraStyle = lib.mkOption {
+        type = lib.types.lines;
+        description = "Additional CSS to put in ~/.config/wlogout/style.css";
+        default = "";
+        example = lib.literalExpression ''
+          button {
+            border-radius: 2px;
+          }
+
+          #lock {
+            background-image: url("''${config.gtk.iconTheme.package}/share/icons/''${config.gtk.iconTheme.name}/apps/scalable/system-lock-screen.svg");
+          }
+        '';
+      };
+    };
+
+  config = lib.mkIf cfg.enable {
+    programs.wlogout.style = lib.concatStrings [
+      ''
+        @import url("${sources.wlogout}/themes/${cfg.flavor}/${cfg.accent}.css");
+      ''
+      (lib.concatMapStrings
+        (icon: ''
+          #${icon} {
+            background-image: url("${sources.wlogout}/icons/${cfg.iconStyle}/${cfg.flavor}/${cfg.accent}/${icon}.svg");
+          }
+        '')
+        [
+          "hibernate"
+          "lock"
+          "logout"
+          "reboot"
+          "shutdown"
+          "suspend"
+        ]
+      )
+      cfg.extraStyle
+    ];
+  };
+}

--- a/modules/tests/darwin.nix
+++ b/modules/tests/darwin.nix
@@ -34,6 +34,7 @@
           swaylock.enable = lib.mkVMOverride false;
           tofi.enable = lib.mkVMOverride false;
           waybar.enable = lib.mkVMOverride false;
+          wlogout.enable = lib.mkVMOverride false;
         };
 
         qt.enable = lib.mkVMOverride false; # NOTE: same as cava

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -58,6 +58,7 @@
     tofi.enable = true;
     obs-studio.enable = true;
     waybar.enable = true;
+    wlogout.enable = true;
     yazi.enable = true;
     zathura.enable = true;
     zed-editor.enable = true;

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -167,6 +167,10 @@
     "hash": "sha256-za0y6hcN2rvN6Xjf31xLRe4PP0YyHu2i454ZPjr+lWA=",
     "rev": "ee8ed32b4f63e9c417249c109818dcc05a2e25da"
   },
+  "wlogout": {
+    "hash": "sha256-QUSDx5M+BG7YqI4MBsOKFPxvZHQtCa8ibT0Ln4FPQ7I=",
+    "rev": "b690cee13b944890e43a5fb629ccdff86cffbbb3"
+  },
   "yazi": {
     "hash": "sha256-UVcPdQFwgBxR6n3/1zRd9ZEkYADkB5nkuom5SxzPTzk=",
     "rev": "5d3a1eecc304524e995fe5b936b8e25f014953e8"

--- a/pkgs/wlogout/package.nix
+++ b/pkgs/wlogout/package.nix
@@ -1,0 +1,10 @@
+{ buildCatppuccinPort }:
+
+buildCatppuccinPort {
+  pname = "wlogout";
+
+  installTargets = [
+    "themes"
+    "icons"
+  ];
+}


### PR DESCRIPTION
Adds support for wlogout.

Extra options I added:
- `iconStyle`, which lets the user specify whether to use the wlogout or wleave-style icons that come with the theme.
- `extraStyle`, which lets the user add extra CSS to ~/.config/wlogout.css

In order for the svg icons to display properly, [`pkgs.librsvg`](https://search.nixos.org/packages?channel=unstable&show=librsvg&from=0&size=50&sort=relevance&type=packages&query=librsvg) needs to be in [`programs.gdk-pixbuf.modulePackages`](https://search.nixos.org/options?channel=unstable&show=programs.gdk-pixbuf.modulePackages&from=0&size=50&sort=relevance&type=packages&query=gdk-pixbuf), but I am not sure if I should add an assertion or warning or something or not.