### PR TITLE
chore(lib): improve mergeEnums

### DIFF
--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -132,9 +132,7 @@ in
 
   # a -> a -> a
   # see https://nlewo.github.io/nixos-manual-sphinx/development/option-types.xml.html
-  # by default enums cannot be merged, but they keep their passed value in `functor.payload`.
-  # `functor.binOp` can merge those values
-  mergeEnums = a: b: lib.types.enum (a.functor.binOp a.functor.payload b.functor.payload);
+  mergeEnums = a: b: a.typeMerge b.functor;
 
   # string
   # returns the current release version of nixos or home-manager. throws an evaluation error if neither are


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/commit/062945b725875167a24b11c4c1f2ba8e7623d3d6

Fixes https://github.com/catppuccin/nix/issues/399

As a workaround, you can do
```diff
-catppuccin.url = "github:catppuccin/nix";
+catppuccin.url = "github:catppuccin/nix?ref=pull/400/head";
```

in your flake.nix