### PR TITLE
fix(home-manager/zed): use correct names

### DIFF
--- a/modules/home-manager/zed-editor.nix
+++ b/modules/home-manager/zed-editor.nix
@@ -17,8 +17,10 @@ in
       extensions = [ "catppuccin" ];
 
       userSettings.theme = {
-        light = "Catppuccin " + cfg.flavor + lib.optionalString cfg.italics " - No Italic";
-        dark = "Catppuccin" + cfg.flavor + lib.optionalString cfg.italics " - No Italic";
+        light =
+          "Catppuccin " + catppuccinLib.mkUpper cfg.flavor + lib.optionalString cfg.italics " - No Italics";
+        dark =
+          "Catppuccin " + catppuccinLib.mkUpper cfg.flavor + lib.optionalString cfg.italics " - No Italics";
       };
     };
   };


### PR DESCRIPTION
Um oopsies

![image](https://github.com/user-attachments/assets/8b026e7d-27e0-4ab9-a013-b0d55496e02b)
