### PR TITLE
fix(home-manager/gtk): pass flavor and not variant

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -158,9 +158,8 @@ in
             "catppuccin-${cfg.flavor}-${cfg.accent}-${cfg.size}"
             + lib.optionalString (cfg.tweaks != [ ]) gtkTweaks;
           package = config.catppuccin.sources.gtk.override {
-            inherit (cfg) size tweaks;
+            inherit (cfg) flavor size tweaks;
             accents = [ cfg.accent ];
-            variant = cfg.flavor;
           };
         };
 


### PR DESCRIPTION
closes https://github.com/catppuccin/nix/issues/428