### PR TITLE
fix(pkgs/nvim): copy overrides from nixpkgs

### DIFF
--- a/pkgs/nvim/package.nix
+++ b/pkgs/nvim/package.nix
@@ -14,6 +14,12 @@ vimUtils.buildVimPlugin rec {
 
   src = sources.${portName};
 
+    nvimSkipModule = [
+      "catppuccin.groups.integrations.noice"
+      "catppuccin.groups.integrations.feline"
+      "catppuccin.lib.vim.init"
+    ];
+
   meta = {
     description = "Soothing pastel theme for ${portName}";
     homepage = "https://github.com/catppuccin/${portName}";


### PR DESCRIPTION
closes #431.

as pointed out in the issue, this works and i just copied [these lines](https://github.com/NixOS/nixpkgs/blob/1a7de5d740a244b99c53e6bff8c60b621637f687/pkgs/applications/editors/vim/plugins/overrides.nix#L276-L282), but i don't fully understand what the exact problem is or why this patch fixes it.
i don't know whether this is feasible, but it might be better to get these overrides from nixpkgs somehow. i can look into that, should it be deemed necessary.