### PR TITLE
feat(home-manager): add support for wezterm

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -49,6 +49,7 @@
   ./tofi.nix
   ./vscode.nix
   ./waybar.nix
+  ./wezterm.nix
   ./wlogout.nix
   ./yazi.nix
   ./zathura.nix

--- a/modules/home-manager/wezterm.nix
+++ b/modules/home-manager/wezterm.nix
@@ -4,18 +4,23 @@
 let
   inherit (config.catppuccin) sources;
   cfg = config.catppuccin.wezterm;
+  applyWeztermTheme = config.catppuccin.wezterm.apply or false;
 in
-
 {
   options.catppuccin.wezterm = catppuccinLib.mkCatppuccinOption { name = "wezterm"; };
 
+  options.catppuccin.wezterm.apply = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = "Apply Catppuccin theme to WezTerm.";
+  };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf (cfg.enable && applyWeztermTheme) {
     programs.wezterm = {
       colorSchemes."catppuccin-${cfg.flavor}" = lib.importTOML "${sources.wezterm}/dist/catppuccin-${cfg.flavor}.toml";
       extraConfig = lib.mkBefore ''
         local config = {}
-        if wezterm.c_builder then
+        if wezterm.config_builder then
           config = wezterm.config_builder()
         end
 

--- a/modules/home-manager/wezterm.nix
+++ b/modules/home-manager/wezterm.nix
@@ -4,28 +4,27 @@
 let
   inherit (config.catppuccin) sources;
   cfg = config.catppuccin.wezterm;
-  applyWeztermTheme = config.catppuccin.wezterm.apply or false;
 in
 {
-  options.catppuccin.wezterm = catppuccinLib.mkCatppuccinOption { name = "wezterm"; };
-
-  options.catppuccin.wezterm.apply = lib.mkOption {
-    type = lib.types.bool;
-    default = false;
-    description = "Apply Catppuccin theme to WezTerm.";
+  options.catppuccin.wezterm = catppuccinLib.mkCatppuccinOption { name = "wezterm"; } // {
+    apply = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Apply Catppuccin theme to WezTerm.";
+    };
   };
 
-  config = lib.mkIf (cfg.enable && applyWeztermTheme) {
+  config = lib.mkIf cfg.enable {
     programs.wezterm = {
       colorSchemes."catppuccin-${cfg.flavor}" = lib.importTOML "${sources.wezterm}/dist/catppuccin-${cfg.flavor}.toml";
-      extraConfig = lib.mkBefore ''
+      extraConfig = lib.mkIf cfg.apply (lib.mkBefore ''
         local config = {}
         if wezterm.config_builder then
           config = wezterm.config_builder()
         end
 
         dofile("${sources.wezterm}/plugin/init.lua").apply_to_config(config)
-      '';
+      '');
     };
   };
 }

--- a/modules/home-manager/wezterm.nix
+++ b/modules/home-manager/wezterm.nix
@@ -17,13 +17,16 @@ in
   config = lib.mkIf cfg.enable {
     programs.wezterm = {
       colorSchemes."catppuccin-${cfg.flavor}" = lib.importTOML "${sources.wezterm}/dist/catppuccin-${cfg.flavor}.toml";
-      extraConfig = lib.mkIf cfg.apply (lib.mkBefore ''
-        local config = {}
-        if wezterm.config_builder then
-          config = wezterm.config_builder()
-        end
+      extraConfig = ''
+        local catppuccin_plugin = "${sources.wezterm}/plugin/init.lua"
+      ''
+      + lib.mkIf cfg.apply (lib.mkBefore ''
+          local config = {}
+          if wezterm.config_builder then
+            config = wezterm.config_builder()
+          end
 
-        dofile("${sources.wezterm}/plugin/init.lua").apply_to_config(config)
+          dofile("${sources.wezterm}/plugin/init.lua").apply_to_config(config)
       '');
     };
   };

--- a/modules/home-manager/wezterm.nix
+++ b/modules/home-manager/wezterm.nix
@@ -20,14 +20,14 @@ in
       extraConfig = ''
         local catppuccin_plugin = "${sources.wezterm}/plugin/init.lua"
       ''
-      + lib.mkIf cfg.apply (lib.mkBefore ''
+      + lib.optionalString cfg.apply ''
           local config = {}
           if wezterm.config_builder then
             config = wezterm.config_builder()
           end
 
           dofile("${sources.wezterm}/plugin/init.lua").apply_to_config(config)
-      '');
+      '';
     };
   };
 }

--- a/modules/home-manager/wezterm.nix
+++ b/modules/home-manager/wezterm.nix
@@ -1,0 +1,26 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+
+let
+  inherit (config.catppuccin) sources;
+  cfg = config.catppuccin.wezterm;
+in
+
+{
+  options.catppuccin.wezterm = catppuccinLib.mkCatppuccinOption { name = "wezterm"; };
+
+
+  config = lib.mkIf cfg.enable {
+    programs.wezterm = {
+      colorSchemes."catppuccin-${cfg.flavor}" = lib.importTOML "${sources.wezterm}/dist/catppuccin-${cfg.flavor}.toml";
+      extraConfig = lib.mkBefore ''
+        local config = {}
+        if wezterm.c_builder then
+          config = wezterm.config_builder()
+        end
+
+        dofile("${sources.wezterm}/plugin/init.lua").apply_to_config(config)
+      '';
+    };
+  };
+}

--- a/modules/home-manager/wezterm.nix
+++ b/modules/home-manager/wezterm.nix
@@ -17,7 +17,7 @@ in
   config = lib.mkIf cfg.enable {
     programs.wezterm = {
       colorSchemes."catppuccin-${cfg.flavor}" = lib.importTOML "${sources.wezterm}/dist/catppuccin-${cfg.flavor}.toml";
-      extraConfig = ''
+      extraConfig = lib.mkBefore (''
         local catppuccin_plugin = "${sources.wezterm}/plugin/init.lua"
       ''
       + lib.optionalString cfg.apply ''
@@ -27,7 +27,7 @@ in
           end
 
           dofile("${sources.wezterm}/plugin/init.lua").apply_to_config(config)
-      '';
+      '');
     };
   };
 }

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -70,6 +70,7 @@
       package = pkgs.vscodium;
     };
     waybar.enable = true;
+    wezterm.enable = true;
     wlogout.enable = true;
     yazi.enable = true;
     zathura.enable = true;

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -234,6 +234,10 @@
     "lastModified": "2024-07-13",
     "rev": "ee8ed32b4f63e9c417249c109818dcc05a2e25da"
   },
+  "wezterm": {
+    "hash": "sha256-McSWoZaJeK+oqdK/0vjiRxZGuLBpEB10Zg4+7p5dIGY=",
+    "rev": "b1a81bae74d66eaae16457f2d8f151b5bd4fe5da"
+  },
   "wlogout": {
     "hash": "sha256-QUSDx5M+BG7YqI4MBsOKFPxvZHQtCa8ibT0Ln4FPQ7I=",
     "lastModified": "2024-11-28",

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -236,6 +236,7 @@
   },
   "wezterm": {
     "hash": "sha256-McSWoZaJeK+oqdK/0vjiRxZGuLBpEB10Zg4+7p5dIGY=",
+    "lastModified": "2023-04-12",
     "rev": "b1a81bae74d66eaae16457f2d8f151b5bd4fe5da"
   },
   "wlogout": {

--- a/pkgs/wezterm/package.nix
+++ b/pkgs/wezterm/package.nix
@@ -1,0 +1,7 @@
+{ buildCatppuccinPort }:
+
+buildCatppuccinPort {
+  pname = "wezterm";
+
+  installTargets = [ "dist" "plugin" ];
+}

--- a/pkgs/wezterm/package.nix
+++ b/pkgs/wezterm/package.nix
@@ -1,7 +1,7 @@
 { buildCatppuccinPort }:
 
 buildCatppuccinPort {
-  pname = "wezterm";
+  port = "wezterm";
 
   installTargets = [ "dist" "plugin" ];
 }


### PR DESCRIPTION
This adds support for WezTerm theme. There are no specific option fo themes in the wezterm home-manager module so I used `extraConfig`.