### PR TITLE
feat: dark and light theme support

### DIFF
--- a/modules/global.nix
+++ b/modules/global.nix
@@ -25,6 +25,20 @@ in
       description = "Global Catppuccin flavor";
     };
 
+    darkFlavor = lib.mkOption {
+      type = catppuccinLib.types.flavor;
+      default = config.catppuccin.flavor;
+      defaultText = "catppuccin.flavor";
+      description = "Global Catppuccin dark flavor";
+    };
+
+    lightFlavor = lib.mkOption {
+      type = catppuccinLib.types.flavor;
+      default = config.catppuccin.flavor;
+      defaultText = "catppuccin.flavor";
+      description = "Global Catppuccin light flavor";
+    };
+
     accent = lib.mkOption {
       type = catppuccinLib.types.accent;
       default = "mauve";

--- a/modules/home-manager/ghostty.nix
+++ b/modules/home-manager/ghostty.nix
@@ -5,20 +5,28 @@ let
   inherit (config.catppuccin) sources;
 
   cfg = config.catppuccin.ghostty;
-  themeName = "catppuccin-${cfg.flavor}";
   enable = cfg.enable && config.programs.ghostty.enable;
+
+  lightThemeName = "catppuccin-${cfg.lightFlavor}";
+  darkThemeName = "catppuccin-${cfg.darkFlavor}";
 in
 {
-  options.catppuccin.ghostty = catppuccinLib.mkCatppuccinOption { name = "ghostty"; };
+  options.catppuccin.ghostty = catppuccinLib.mkCatppuccinOption {
+    name = "ghostty";
+    darkLightSupport = true;
+  };
 
   config = lib.mkIf enable {
     xdg.configFile = {
-      "ghostty/themes/${themeName}".source = "${sources.ghostty}/${themeName}.conf";
+      "ghostty/themes/${lightThemeName}".source = "${sources.ghostty}/${lightThemeName}.conf";
+    }
+    // lib.optionalAttrs (lightThemeName != darkThemeName) {
+      "ghostty/themes/${darkThemeName}".source = "${sources.ghostty}/${darkThemeName}.conf";
     };
 
     programs.ghostty = {
       settings = {
-        theme = "light:${themeName},dark:${themeName}";
+        theme = "light:${lightThemeName},dark:${darkThemeName}";
       };
     };
   };

--- a/modules/home-manager/vicinae.nix
+++ b/modules/home-manager/vicinae.nix
@@ -9,22 +9,20 @@ in
   options.catppuccin.vicinae = catppuccinLib.mkCatppuccinOption {
     name = "vicinae";
     accentSupport = true;
+    darkLightSupport = true;
   };
 
   config = lib.mkIf cfg.enable {
     programs.vicinae = {
-      settings = {
-        theme =
-          let
-            themeConfiguration = {
-              name = "catppuccin-${cfg.flavor}";
-              iconTheme = "Catppuccin ${lib.toSentenceCase cfg.flavor} ${lib.toSentenceCase cfg.accent}";
-            };
-          in
-          {
-            light = themeConfiguration;
-            dark = themeConfiguration;
-          };
+      settings.theme = {
+        light = {
+          name = "catppuccin-${cfg.lightFlavor}";
+          iconTheme = "Catppuccin ${lib.toSentenceCase cfg.lightFlavor} ${lib.toSentenceCase cfg.accent}";
+        };
+        dark = {
+          name = "catppuccin-${cfg.darkFlavor}";
+          iconTheme = "Catppuccin ${lib.toSentenceCase cfg.darkFlavor} ${lib.toSentenceCase cfg.accent}";
+        };
       };
     };
   };

--- a/modules/home-manager/zed-editor.nix
+++ b/modules/home-manager/zed-editor.nix
@@ -8,7 +8,6 @@ let
   enable = cfg.enable && config.programs.zed-editor.enable;
 
   accent = if cfg.accent == "mauve" then "" else " (${cfg.accent})";
-  flavor = catppuccinLib.mkFlavorName cfg.flavor;
 in
 
 {
@@ -16,6 +15,7 @@ in
     catppuccinLib.mkCatppuccinOption {
       name = "zed";
       accentSupport = true;
+      darkLightSupport = true;
     }
     // {
       italics = lib.mkEnableOption "the italicized version of theme" // {
@@ -35,8 +35,16 @@ in
           "Catppuccin " + (catppuccinLib.mkFlavorName cfg.icons.flavor)
         );
         theme = {
-          light = "Catppuccin " + flavor + accent + lib.optionalString (!cfg.italics) " - No Italics";
-          dark = "Catppuccin " + flavor + accent + lib.optionalString (!cfg.italics) " - No Italics";
+          light =
+            "Catppuccin "
+            + (catppuccinLib.mkFlavorName cfg.lightFlavor)
+            + accent
+            + lib.optionalString (!cfg.italics) " - No Italics";
+          dark =
+            "Catppuccin "
+            + (catppuccinLib.mkFlavorName cfg.darkFlavor)
+            + accent
+            + lib.optionalString (!cfg.italics) " - No Italics";
         };
       };
     };

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -184,6 +184,7 @@ lib.makeExtensible (ctp: {
       default ? if useGlobalEnable then config.catppuccin.enable else false,
       defaultText ? if useGlobalEnable then "catppuccin.enable" else null,
       accentSupport ? false,
+      darkLightSupport ? false,
     }:
 
     {
@@ -209,6 +210,21 @@ lib.makeExtensible (ctp: {
         default = config.catppuccin.accent;
         defaultText = "catppuccin.accent";
         description = "Catppuccin accent for ${name}";
+      };
+    }
+    // optionalAttrs darkLightSupport {
+      darkFlavor = mkOption {
+        type = ctp.types.flavor;
+        default = config.catppuccin.darkFlavor;
+        defaultText = "catppuccin.darkFlavor";
+        description = "Catppuccin dark flavor for ${name}";
+      };
+
+      lightFlavor = mkOption {
+        type = ctp.types.flavor;
+        default = config.catppuccin.lightFlavor;
+        defaultText = "catppuccin.lightFlavor";
+        description = "Catppuccin light flavor for ${name}";
       };
     };
 

--- a/modules/nixos/home-assistant.nix
+++ b/modules/nixos/home-assistant.nix
@@ -15,6 +15,7 @@ in
     catppuccinLib.mkCatppuccinOption {
       name = "home-assistant";
       accentSupport = true;
+      darkLightSupport = true;
     }
     // {
       setDefaultAtStartup = lib.mkEnableOption "setting the default theme at Home Assistant startup" // {
@@ -30,7 +31,7 @@ in
       "automation catppuccin" = lib.mkIf cfg.setDefaultAtStartup {
         alias = "Catppuccin default theme";
         id = "catppuccin_default_theme";
-        description = "Sets the default frontend theme to ${catppuccinLib.mkFlavorName cfg.flavor} at startup.";
+        description = "Sets the default frontend theme to catppuccin at startup.";
         mode = "single";
         triggers = singleton {
           trigger = "homeassistant";
@@ -39,8 +40,8 @@ in
         actions = singleton {
           action = "frontend.set_theme";
           data = {
-            name = "Catppuccin ${toSentenceCase cfg.flavor} ${toSentenceCase cfg.accent}";
-            name_dark = "none";
+            name = "Catppuccin ${toSentenceCase cfg.lightFlavor} ${toSentenceCase cfg.accent}";
+            name_dark = "Catppuccin ${toSentenceCase cfg.darkFlavor} ${toSentenceCase cfg.accent}";
           };
         };
       };


### PR DESCRIPTION
Perhaps a oversight but a understandable one seeing as we currently only have 1 reactive theme, zed. But that may change with the addition of ghostty!

closes https://github.com/catppuccin/nix/issues/420

The idea here was to introduce `darkFlavor` and `lightFlavor` in a very none breaking way, such that they both default to `config.catppuccin.flavor` rather then `mocha` and `latte` respectively.