### PR TITLE
refactor(home-manager/alacritty): remove importTOML

### DIFF
--- a/modules/home-manager/alacritty.nix
+++ b/modules/home-manager/alacritty.nix
@@ -20,7 +20,7 @@ in
 
   config = lib.mkIf cfg.enable {
     programs.alacritty = {
-      settings = lib.importTOML "${sources.alacritty}/catppuccin-${cfg.flavor}.toml";
+      settings.general.import = lib.mkBefore [ "${sources.alacritty}/catppuccin-${cfg.flavor}.toml" ];
     };
   };
 }


### PR DESCRIPTION
We can use the `import` setting within alacritty to import the file with the least presidence, this is beacuse anything within the `alacritty.toml` file has greater precedence and other files imported will be loaded after the imported catppuccin theme beacuse of the `lib.mkBefore`.

For futher reading consult
https://alacritty.org/config-alacritty.html#s1