### PR TITLE
home-manager: remove IFD from helix and yazi

### DIFF
--- a/modules/home-manager/helix.nix
+++ b/modules/home-manager/helix.nix
@@ -5,6 +5,7 @@ let
   inherit (config.catppuccin) sources;
 
   cfg = config.catppuccin.helix;
+  enable = cfg.enable && config.programs.helix.enable;
   subdir = if cfg.useItalics then "default" else "no_italics";
 in
 
@@ -38,15 +39,17 @@ in
       )
     ];
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf enable {
     programs.helix = {
       settings = {
         theme = "catppuccin-${cfg.flavor}";
         editor.color-modes = lib.mkDefault true;
       };
+    };
 
-      themes."catppuccin-${cfg.flavor}" =
-        lib.importTOML "${sources.helix}/${subdir}/catppuccin_${cfg.flavor}.toml";
+    xdg.configFile = {
+      "helix/themes/catppuccin-${cfg.flavor}.toml".source =
+        "${sources.helix}/${subdir}/catppuccin_${cfg.flavor}.toml";
     };
   };
 }

--- a/modules/home-manager/yazi.nix
+++ b/modules/home-manager/yazi.nix
@@ -25,11 +25,10 @@ in
   };
 
   config = lib.mkIf enable {
-    programs.yazi = {
-      theme = lib.importTOML "${sources.yazi}/${cfg.flavor}/catppuccin-${cfg.flavor}-${cfg.accent}.toml";
-    };
-
     xdg.configFile = {
+      "yazi/theme.toml".source =
+        "${sources.yazi}/${cfg.flavor}/catppuccin-${cfg.flavor}-${cfg.accent}.toml";
+
       "yazi/Catppuccin-${cfg.flavor}.tmTheme".source =
         "${sources.bat}/Catppuccin ${catppuccinLib.mkUpper cfg.flavor}.tmTheme";
     };


### PR DESCRIPTION
Removes IFD. This shouldn't break themes. but if someone was previously using some form of `lib.mkForce` on these settings they will break.