### PR TITLE
fix(home-manager/alacritty): remove the `general` setting option

### DIFF
--- a/modules/home-manager/alacritty.nix
+++ b/modules/home-manager/alacritty.nix
@@ -20,7 +20,7 @@ in
 
   config = lib.mkIf cfg.enable {
     programs.alacritty = {
-      settings.general.import = lib.mkBefore [ "${sources.alacritty}/catppuccin-${cfg.flavor}.toml" ];
+      settings.import = lib.mkBefore [ "${sources.alacritty}/catppuccin-${cfg.flavor}.toml" ];
     };
   };
 }


### PR DESCRIPTION
## Summary
This pull request fixes an issue in the Home-Manager Alacritty module related to the placement of the `import` config key in the generated `alacritty.toml` configuration file.

## Problem
The current implementation of the Alacritty module defines the `import` config key as follows:
```nix
settings.general.import = lib.mkBefore [ "${sources.alacritty}/catppuccin-${cfg.flavor}.toml" ];
```
This results in a configuration file with the following structure:
```toml
[general]
import = ["..."]
```
However, according to Alacritty's documentation, global settings like import must be declared at the top level of the TOML file. They should not be nested under a [general] section. The correct structure should be:
```toml
import = ["..."]

[other_options]
...
```

## Solution
This pull request modifies the module to define the `import` config key at the top level by replacing
`settings.general.import` with `settings.import`.