### PR TITLE
revert: "fix(home-manager/alacritty): remove the `general` setting option"

### DIFF
--- a/modules/home-manager/alacritty.nix
+++ b/modules/home-manager/alacritty.nix
@@ -20,7 +20,7 @@ in
 
   config = lib.mkIf cfg.enable {
     programs.alacritty = {
-      settings.import = lib.mkBefore [ "${sources.alacritty}/catppuccin-${cfg.flavor}.toml" ];
+      settings.general.import = lib.mkBefore [ "${sources.alacritty}/catppuccin-${cfg.flavor}.toml" ];
     };
   };
 }


### PR DESCRIPTION
Reverts catppuccin/nix#450

https://github.com/catppuccin/nix/pull/450#issuecomment-2571501256