### PR TITLE
feat(home-manager): add support for lsd

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -27,6 +27,7 @@
   ./kitty.nix
   ./kvantum.nix
   ./lazygit.nix
+  ./lsd.nix
   ./newsboat.nix
   ./mako.nix
   ./micro.nix

--- a/modules/home-manager/lsd.nix
+++ b/modules/home-manager/lsd.nix
@@ -19,6 +19,9 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    programs.lsd.colors = catppuccinLib.importYAML "${sources.lsd}/catppuccin-${cfg.flavor}/colors.yaml";
+    xdg.configFile = {
+      "lsd/config.yaml".source = "${sources.lsd}/catppuccin-${cfg.flavor}/colors.yaml";
+    };
+    programs.lsd.settings.color.theme = "custom";
   };
 }

--- a/modules/home-manager/lsd.nix
+++ b/modules/home-manager/lsd.nix
@@ -13,7 +13,7 @@ in
 
   config = lib.mkIf enable {
     xdg.configFile = {
-      "lsd/config.yaml".source = "${sources.lsd}/catppuccin-${cfg.flavor}/colors.yaml";
+      "lsd/colors.yaml".source = "${sources.lsd}/catppuccin-${cfg.flavor}/colors.yaml";
     };
     programs.lsd.settings.color.theme = "custom";
   };

--- a/modules/home-manager/lsd.nix
+++ b/modules/home-manager/lsd.nix
@@ -1,0 +1,24 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+
+let
+  inherit (config.catppuccin) sources;
+  cfg = config.catppuccin.lsd;
+in
+
+{
+  options.catppuccin.lsd = catppuccinLib.mkCatppuccinOption { name = "lsd"; };
+
+  imports = catppuccinLib.mkRenamedCatppuccinOptions {
+    from = [
+      "programs"
+      "lsd"
+      "catppuccin"
+    ];
+    to = "lsd";
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.lsd.colors = catppuccinLib.importYAML "${sources.lsd}/catppuccin-${cfg.flavor}/colors.yaml";
+  };
+}

--- a/modules/home-manager/lsd.nix
+++ b/modules/home-manager/lsd.nix
@@ -3,7 +3,9 @@
 
 let
   inherit (config.catppuccin) sources;
+
   cfg = config.catppuccin.lsd;
+  enable = cfg.enable && config.programs.lsd.enable;
 in
 
 {
@@ -18,7 +20,7 @@ in
     to = "lsd";
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf enable {
     xdg.configFile = {
       "lsd/config.yaml".source = "${sources.lsd}/catppuccin-${cfg.flavor}/colors.yaml";
     };

--- a/modules/home-manager/lsd.nix
+++ b/modules/home-manager/lsd.nix
@@ -11,15 +11,6 @@ in
 {
   options.catppuccin.lsd = catppuccinLib.mkCatppuccinOption { name = "lsd"; };
 
-  imports = catppuccinLib.mkRenamedCatppuccinOptions {
-    from = [
-      "programs"
-      "lsd"
-      "catppuccin"
-    ];
-    to = "lsd";
-  };
-
   config = lib.mkIf enable {
     xdg.configFile = {
       "lsd/config.yaml".source = "${sources.lsd}/catppuccin-${cfg.flavor}/colors.yaml";

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -46,6 +46,7 @@
     k9s.enable = true;
     kitty.enable = true;
     lazygit.enable = true;
+    lsd.enable = true;
     micro.enable = true;
     mpv.enable = true;
     neovim.enable = true;

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -91,6 +91,10 @@
     "hash": "sha256-b2SoIeXT1BaoxvEeQ0VaPmnBND+7qUe342kOIkyOcAc=",
     "rev": "d3c95a67ea3f778f7705d8ef814f87ac5213436d"
   },
+  "lsd": {
+    "hash": "sha256-lf6VawCgK9VlKO+PAzPD/WqPjxoqw2j000b5ZlEXj/Y=",
+    "rev": "7085155432c7fe53a7acd7b0c004955368aa0fba"
+  },
   "mako": {
     "hash": "sha256-jgiZ+CrM4DX2nZR5BjjD9/Rk5CGGUy3gq9CCvYzp5Vs=",
     "rev": "92844f144e72f2dc8727879ec141ffdacf3ff6a1"


### PR DESCRIPTION
Add support for the LSD program.

In particular, the module defines the `programs.lsd.colors` option to be correspondent `themes/catppuccin-<flavor>/colors.yaml` file of the [LSD port](https://github.com/catppuccin/lsd).