### PR TITLE
feat(home-manager/neovim): add option for custom settings

### DIFF
--- a/modules/home-manager/neovim.nix
+++ b/modules/home-manager/neovim.nix
@@ -7,10 +7,38 @@
 
 let
   cfg = config.catppuccin.nvim;
+
+  toLuaValue =
+    value:
+    if builtins.isAttrs value then
+      toLuaTable value
+    else if lib.isString value || lib.isPath value then
+      ''"${toString value}"''
+    else if lib.isList value then
+      "{${lib.strings.concatStringsSep "," (map toLuaValue value)}}"
+    else if lib.isBool value then
+      if value == true then "true" else "false"
+    else
+      toString value;
+
+  toLuaTable =
+    attrset:
+    let
+      values = lib.strings.concatStringsSep "," (
+        lib.attrsets.mapAttrsToList (name: value: "${name} = ${toLuaValue value}") attrset
+      );
+    in
+    "{${values}}";
 in
 
 {
-  options.catppuccin.nvim = catppuccinLib.mkCatppuccinOption { name = "neovim"; };
+  options.catppuccin.nvim = catppuccinLib.mkCatppuccinOption { name = "neovim"; } // {
+    extraConfig = lib.mkOption {
+      description = "Extra settings that will be passed to the setup function.";
+      default = { };
+      type = lib.types.attrs;
+    };
+  };
 
   imports = catppuccinLib.mkRenamedCatppuccinOptions {
     from = [
@@ -32,10 +60,18 @@ in
               vim.fn.mkdir(compile_path, "p")
               vim.opt.runtimepath:append(compile_path)
 
-              require("catppuccin").setup({
-              	compile_path = compile_path,
-              	flavour = "${cfg.flavor}",
-              })
+              local catppuccin_custom_plugin_settings = ${toLuaTable cfg.extraConfig}
+
+              local catppuccin_plugin_settings = {
+                compile_path = compile_path,
+                flavour = "${cfg.flavor}",
+              }
+
+              for key, value in pairs(catppuccin_custom_plugin_settings) do
+                catppuccin_plugin_settings[key] = value
+              end
+
+              require("catppuccin").setup(catppuccin_plugin_settings)
 
               vim.api.nvim_command("colorscheme catppuccin")
             EOF

--- a/modules/home-manager/neovim.nix
+++ b/modules/home-manager/neovim.nix
@@ -1,36 +1,14 @@
 { catppuccinLib }:
-{
-  config,
-  lib,
-  ...
-}:
-
+{ config, lib, ... }:
 let
   cfg = config.catppuccin.nvim;
+  pluginSettings = lib.generators.toLua { } (defaultConfig // cfg.extraConfig);
 
-  toLuaValue =
-    value:
-    if builtins.isAttrs value then
-      toLuaTable value
-    else if lib.isString value || lib.isPath value then
-      ''"${toString value}"''
-    else if lib.isList value then
-      "{${lib.strings.concatStringsSep "," (map toLuaValue value)}}"
-    else if lib.isBool value then
-      if value == true then "true" else "false"
-    else
-      toString value;
-
-  toLuaTable =
-    attrset:
-    let
-      values = lib.strings.concatStringsSep "," (
-        lib.attrsets.mapAttrsToList (name: value: "${name} = ${toLuaValue value}") attrset
-      );
-    in
-    "{${values}}";
+  defaultConfig = {
+    compile_path = lib.generators.mkLuaInline "compile_path";
+    flavour = cfg.flavor;
+  };
 in
-
 {
   options.catppuccin.nvim = catppuccinLib.mkCatppuccinOption { name = "neovim"; } // {
     extraConfig = lib.mkOption {
@@ -60,18 +38,7 @@ in
               vim.fn.mkdir(compile_path, "p")
               vim.opt.runtimepath:append(compile_path)
 
-              local catppuccin_custom_plugin_settings = ${toLuaTable cfg.extraConfig}
-
-              local catppuccin_plugin_settings = {
-                compile_path = compile_path,
-                flavour = "${cfg.flavor}",
-              }
-
-              for key, value in pairs(catppuccin_custom_plugin_settings) do
-                catppuccin_plugin_settings[key] = value
-              end
-
-              require("catppuccin").setup(catppuccin_plugin_settings)
+              require("catppuccin").setup(${pluginSettings})
 
               vim.api.nvim_command("colorscheme catppuccin")
             EOF

--- a/modules/home-manager/neovim.nix
+++ b/modules/home-manager/neovim.nix
@@ -2,7 +2,6 @@
 { config, lib, ... }:
 let
   cfg = config.catppuccin.nvim;
-  pluginSettings = lib.generators.toLua { } (defaultConfig // cfg.extraConfig);
 
   defaultConfig = {
     compile_path = lib.generators.mkLuaInline "compile_path";
@@ -11,10 +10,11 @@ let
 in
 {
   options.catppuccin.nvim = catppuccinLib.mkCatppuccinOption { name = "neovim"; } // {
-    extraConfig = lib.mkOption {
+    settings = lib.mkOption {
       description = "Extra settings that will be passed to the setup function.";
       default = { };
-      type = lib.types.attrs;
+      type = lib.types.submodule { freeformType = lib.types.attrsOf lib.types.anything; };
+      apply = lib.recursiveUpdate defaultConfig;
     };
   };
 
@@ -38,7 +38,7 @@ in
               vim.fn.mkdir(compile_path, "p")
               vim.opt.runtimepath:append(compile_path)
 
-              require("catppuccin").setup(${pluginSettings})
+              require("catppuccin").setup(${lib.generators.toLua { } cfg.settings})
 
               vim.api.nvim_command("colorscheme catppuccin")
             EOF


### PR DESCRIPTION
This commit adds an `extraConfig` option to the neovim options that gets dynamically converted into a Lua table and passed to the setup function which is useful for configuring things like italics, transparent_background,...

Fixes this issue: https://github.com/catppuccin/nix/issues/259