### PR TITLE
ci: build for aarch64-linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, macos-13, ubuntu-latest ]
+        os: [ macos-latest, macos-13, ubuntu-latest, ubuntu-24.04-arm ]
 
     runs-on: ${{ matrix.os }}
 
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest ]
+        os: [ macos-latest, ubuntu-latest, ubuntu-24.04-arm ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
GitHub's Linux aarch64 runners are now in [public preview](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/). Lets use them! :p
