### PR TITLE
chore: set module class

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,6 +1,8 @@
 { lib, ... }:
 
 {
+  _class = "homeManager";
+
   imports = [
     (lib.modules.importApply ../global.nix { catppuccinModules = import ./all-modules.nix; })
   ];

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,6 +1,8 @@
 { lib, ... }:
 
 {
+  _class = "nixos";
+
   imports = [
     (lib.modules.importApply ../global.nix { catppuccinModules = import ./all-modules.nix; })
   ];


### PR DESCRIPTION
this *should* help prevent errors from utilising the wrong class for the diffrent system types. e.g. darwin trying to use nixos modules