### PR TITLE
refactor: console -> tty

### DIFF
--- a/modules/nixos/tty.nix
+++ b/modules/nixos/tty.nix
@@ -10,7 +10,7 @@ let
 in
 
 {
-  options.catppuccin.tty = catppuccinLib.mkCatppuccinOption { name = "console"; };
+  options.catppuccin.tty = catppuccinLib.mkCatppuccinOption { name = "tty"; };
 
   imports = catppuccinLib.mkRenamedCatppuccinOptions {
     from = [


### PR DESCRIPTION
likely forgotten when we moved to the namespace