### PR TITLE
ci: add update-locks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ on:
 
       - '.github/workflows/ci.yml'
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+
 
 jobs:
   packages:
@@ -32,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || 'main' }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@V27
@@ -63,6 +71,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || 'main' }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@V27

--- a/.github/workflows/update-locks.yml
+++ b/.github/workflows/update-locks.yml
@@ -1,0 +1,88 @@
+name: Update lockfiles
+
+on:
+  schedule:
+    # run every friday
+    - cron: "0 0 * * 5"
+  workflow_dispatch:
+
+jobs:
+  flake:
+    name: Update flake.lock
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          # NOTE: Required for subflake
+          install_url: https://releases.nixos.org/nix/nix-2.26.0/install
+
+      - name: Update Flakes
+        run: |
+          nix flake update .
+          nix flake update ./dev
+
+      - name:  Create pull request
+        id: create-pull-request 
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          commit-message: "chore: update flakes"
+          title: "chore: update flakes"
+          signoff: true
+          sign-commits: true
+          branch: "update-flake-lock"
+
+      - name: Check
+        uses: ./.github/workflows/ci.yml
+        with:
+          ref: ${{ steps.create-pull-request.outputs.pull-request-head-sha }}
+
+
+  ports:
+    name: Update port sources
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@V27
+
+      - name: Install python
+        run: nix profile install --inputs-from . 'nixpkgs#python3'
+
+      - name: Update ports
+        run: ./pkgs/paws.py
+
+      - name: Create pull request
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          commit-message: "chore: update port sources"
+          title: "chore: update port sources"
+          signoff: true
+          sign-commits: true
+          branch: "update-ports"
+
+      - name: Check
+        uses: ./.github/workflows/ci.yml
+        with:
+          ref: ${{ steps.create-pull-request.outputs.pull-request-head-sha }}
+


### PR DESCRIPTION
I recently notice we were not getting updates for ports. Seems to have been dropped in https://github.com/catppuccin/nix/commit/115c3de5635c257bd2a723e06f8262a5edd66d9c. This PR adds that back and runs the test suite against those changes