### PR TITLE
feat(darwin): init

### DIFF
--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -39,16 +39,36 @@
         ]
       },
       "locked": {
-        "lastModified": 1779336838,
-        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
         "type": "github"
       }
     },
@@ -73,6 +93,7 @@
         "catppuccin": "catppuccin",
         "flake-utils": "flake-utils",
         "home-manager": "home-manager",
+        "nix-darwin": "nix-darwin",
         "nixpkgs": [
           "catppuccin",
           "nixpkgs"

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -13,12 +13,18 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
     {
       self,
       nixpkgs,
+      nix-darwin,
       catppuccin,
       ...
     }@inputs:
@@ -71,8 +77,8 @@
               else
                 "/home/${config.home.username}"
             );
-            # See comment in NixOS config below
-            inherit (osConfig.system or self.nixosConfigurations.pepperjack-pc.config.system) stateVersion;
+
+            stateVersion = config.home.version.release;
           };
         };
     in
@@ -85,6 +91,18 @@
 
         # Evaluate each of our modules for different systems
         nixosConfiguration = self.nixosConfigurations.pepperjack-pc.extendModules {
+          modules = [
+            (
+              { lib, ... }:
+
+              {
+                nixpkgs.pkgs = lib.mkForce pkgs;
+              }
+            )
+          ];
+        };
+
+        darwinConfigurations = self.darwinConfigurations.pepperjack-pc.extendModules {
           modules = [
             (
               { lib, ... }:
@@ -113,7 +131,7 @@
           if pkgs.stdenv.hostPlatform.isLinux then
             nixosConfiguration.config.system.build.toplevel.outPath
           else
-            homeConfiguration.activationPackage.outPath;
+            darwinConfigurations.config.system.build.toplevel.outPath;
 
         mkOptionsJSONFrom =
           eval:
@@ -144,61 +162,80 @@
 
         packages = {
           nixosOptionsJSON = mkOptionsJSONFrom nixosConfiguration;
+          darwinOptionsJSON = mkOptionsJSONFrom darwinConfigurations;
           homeOptionsJSON = mkOptionsJSONFrom homeConfiguration;
         };
       }
     )
-    // (
-      let
-        pkgs = nixpkgs.legacyPackages.x86_64-linux;
-      in
-
-      {
-        homeConfigurations = {
-          pepperjack = inputs.home-manager.lib.homeManagerConfiguration {
-            inherit pkgs;
-            modules = [
-              pepperjackHomeModule
-              { home.username = "pepperjack"; }
-            ];
-          };
+    // {
+      homeConfigurations = {
+        pepperjack = inputs.home-manager.lib.homeManagerConfiguration {
+          pkgs = nixpkgs.legacyPackages.x86_64-linux;
+          modules = [
+            pepperjackHomeModule
+            { home.username = "pepperjack"; }
+          ];
         };
+      };
 
-        nixosConfigurations = {
-          pepperjack-pc = nixpkgs.lib.nixosSystem {
-            modules = [
-              inputs.home-manager.nixosModules.default
-              catppuccin.nixosModules.catppuccin
-              catppuccinEnableModule
-              (catppuccin + "/modules/tests/nixos.nix")
+      nixosConfigurations = {
+        pepperjack-pc = nixpkgs.lib.nixosSystem {
+          modules = [
+            inputs.home-manager.nixosModules.default
+            catppuccin.nixosModules.catppuccin
+            catppuccinEnableModule
+            (catppuccin + "/modules/tests/nixos.nix")
 
-              (
-                { config, ... }:
+            (
+              { config, ... }:
 
-                {
-                  # Silence, convenient safety assertions!!!!
-                  fileSystems."/" = {
-                    label = "root";
-                    fsType = "auto";
-                  };
+              {
+                # Silence, convenient safety assertions!!!!
+                fileSystems."/" = {
+                  label = "root";
+                  fsType = "auto";
+                };
 
-                  # NOTE: This isn't required for NixOS. But it is for home-manager!
-                  system.stateVersion = config.system.nixos.release;
+                system.stateVersion = config.system.nixos.release;
 
-                  nixpkgs = { inherit pkgs; };
+                nixpkgs.pkgs = nixpkgs.legacyPackages.x86_64-linux;
 
-                  users.users.pepperjack = {
-                    isNormalUser = true;
-                  };
+                users.users.pepperjack = {
+                  isNormalUser = true;
+                };
 
-                  home-manager.users.pepperjack = {
-                    imports = [ pepperjackHomeModule ];
-                  };
-                }
-              )
-            ];
-          };
+                home-manager.users.pepperjack = {
+                  imports = [ pepperjackHomeModule ];
+                };
+              }
+            )
+          ];
         };
-      }
-    );
+      };
+
+      darwinConfigurations = {
+        pepperjack-pc = nix-darwin.lib.darwinSystem {
+          modules = [
+            inputs.home-manager.darwinModules.default
+            catppuccin.darwinModules.catppuccin
+            catppuccinEnableModule
+            (catppuccin + "/modules/tests/darwin.nix")
+
+            {
+              system.stateVersion = 5;
+
+              nixpkgs.pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+
+              users.users.pepperjack = {
+                home = "/Users/pepperjack";
+              };
+
+              home-manager.users.pepperjack = {
+                imports = [ pepperjackHomeModule ];
+              };
+            }
+          ];
+        };
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -121,5 +121,10 @@
           file = ./modules/nixos;
         };
       };
+
+      darwinModules.catppuccin = mkModule {
+        type = "darwin";
+        file = ./modules/darwin;
+      };
     };
 }

--- a/modules/darwin/all-modules.nix
+++ b/modules/darwin/all-modules.nix
@@ -1,0 +1,5 @@
+[
+  # keep-sorted start
+  ./fish.nix
+  # keep-sorted end
+]

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -1,0 +1,9 @@
+{ lib, ... }:
+
+{
+  _class = "darwin";
+
+  imports = [
+    (lib.modules.importApply ../global.nix { catppuccinModules = import ./all-modules.nix; })
+  ];
+}

--- a/modules/darwin/fish.nix
+++ b/modules/darwin/fish.nix
@@ -1,0 +1,28 @@
+{ catppuccinLib }:
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  inherit (config.catppuccin) sources;
+
+  cfg = config.catppuccin.fish;
+  enable = cfg.enable && config.programs.fish.enable;
+
+  themeName = "catppuccin-${cfg.flavor}";
+in
+
+{
+  options.catppuccin.fish = catppuccinLib.mkCatppuccinOption { name = "fish"; };
+
+  config = lib.mkIf enable {
+    environment.etc."fish/themes/${themeName}.theme".source =
+      "${sources.fish}/static/${themeName}.theme";
+
+    programs.fish.shellInit = ''
+      fish_config theme choose "${themeName}"
+    '';
+  };
+}

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -230,7 +230,7 @@ lib.makeExtensible (ctp: {
     ```
   */
   getModuleRelease =
-    config.home.version.release or config.system.nixos.release
+    config.home.version.release or config.system.nixos.release or config.system.darwinRelease
       or (throw "Couldn't determine release version!");
 
   /**

--- a/modules/tests/darwin.nix
+++ b/modules/tests/darwin.nix
@@ -1,0 +1,5 @@
+{
+  programs = {
+    fish.enable = true;
+  };
+}


### PR DESCRIPTION
previously it made no sense to add this since we didn't support any darwin modules but now we have the global `cache.enable` and some users may want to set it in a "shared" module between nixos and darwin

closes https://github.com/catppuccin/nix/issues/162