### PR TITLE
ci: avoid having to approve first time contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - 'pkgs/**'
 
       - '.github/workflows/ci.yml'
-  pull_request:
+  pull_request_target:
     paths:
       - '**.lock'
       - '**.nix'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -11,7 +11,7 @@ on:
       - 'CHANGELOG.md'
 
       - '.github/workflows/website.yml'
-  pull_request:
+  pull_request_target:
     paths:
       - '**.lock'
       - '**.nix'


### PR DESCRIPTION
`pull_request` -> `pull_request_target` means that we don't need to approve first time contributors.