### PR TITLE
ci: disable nix in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,5 @@
   "extends": [
     "config:recommended",
     "schedule:weekly"
-  ],
-  "nix": {
-    "enabled": true,
-  }
+  ]
 }


### PR DESCRIPTION
Forgot to remove this in https://github.com/catppuccin/nix/pull/476. It's what was meant to replace the workflow, but obviously doesn't work :/
