### PR TITLE
ci: use workflow_dispatch over workflow_call in update-locks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,6 @@ on:
 
       - '.github/workflows/ci.yml'
   workflow_dispatch:
-  workflow_call:
-    inputs:
-      ref:
-        required: true
-        type: string
 
 
 jobs:
@@ -38,8 +33,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || 'main' }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@V27
@@ -71,8 +64,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || 'main' }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@V27

--- a/.github/workflows/update-locks.yml
+++ b/.github/workflows/update-locks.yml
@@ -42,11 +42,10 @@ jobs:
           sign-commits: true
           branch: "update-flake-lock"
 
-      - name: Check
-        uses: ./.github/workflows/ci.yml
-        with:
-          ref: ${{ steps.create-pull-request.outputs.pull-request-head-sha }}
-
+      - name: Run CI
+        run: |
+          gh workflow run ci.yml \
+            --ref ${{ steps.create-pull-request.outputs.pull-request-branch }}
 
   ports:
     name: Update port sources
@@ -81,8 +80,7 @@ jobs:
           sign-commits: true
           branch: "update-ports"
 
-      - name: Check
-        uses: ./.github/workflows/ci.yml
-        with:
-          ref: ${{ steps.create-pull-request.outputs.pull-request-head-sha }}
-
+      - name: Run CI
+        run: |
+          gh workflow run ci.yml \
+            --ref ${{ steps.create-pull-request.outputs.pull-request-branch }}


### PR DESCRIPTION
`workflow_call` only works for jobs, not steps
