### PR TITLE
fix(pkgs/paws): set timezone to UTC for fetcher

### DIFF
--- a/pkgs/paws.py
+++ b/pkgs/paws.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import subprocess
 from multiprocessing import cpu_count
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Directory of the current script
@@ -59,7 +59,7 @@ async def handle_port(sources: dict, port: str, remove=False):
 	else:
 		data = await fetch_port(port)
 		locked = data["locked"]
-		last_modified = datetime.fromtimestamp(int(locked["lastModified"])).strftime('%Y-%m-%d')
+		last_modified = datetime.fromtimestamp(int(locked["lastModified"]), tz = timezone.utc).strftime('%Y-%m-%d')
 		sources[port] = {"rev": locked["rev"], "hash": locked["narHash"], "lastModified": last_modified}
 
 


### PR DESCRIPTION
By default [`datetime.datetimefromtimestamp`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp) uses localtime , so to prevent more "spammy" sources.json changes, like https://github.com/catppuccin/nix/pull/501, lets set the timezone to UTC.