### PR TITLE
feat(home-manager): add support for sioyak

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -58,4 +58,5 @@
   ./zed-editor.nix
   ./zellij.nix
   ./zsh-syntax-highlighting.nix
+  ./sioyek.nix
 ]

--- a/modules/home-manager/sioyek.nix
+++ b/modules/home-manager/sioyek.nix
@@ -12,29 +12,11 @@ let
 in
  
 {
-  options.catppuccin.sioyek = 
-    catppuccinLib.mkCatppuccinOption {
-      name = "sioyek";
-    }
-    // {
-      applyOnStartup = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Applies the theme by adding `toggle_custom_color` to `startup_commands` in sioyek's config.
-          If this is disabled, you must manually run `toggle_custom_colors` in Sioyek to enable the theme.
-        '';
-      };
-    };
-
+  options.catppuccin.sioyek = catppuccinLib.mkCatppuccinOption {
+    name = "sioyek";
+  };
 
   config = lib.mkIf enable {
-    xdg.configFile = {
-      "sioyek/prefs_user.config".source = theme;
-    };
-    
-    programs.sioyek.config = lib.mkIf cfg.applyOnStartup {
-      startup_commands = lib.mkBefore "toggle_custom_color;";
-    };
+    programs.sioyek.config = catppuccinLib.importINI theme;
   };
 } 

--- a/modules/home-manager/sioyek.nix
+++ b/modules/home-manager/sioyek.nix
@@ -27,14 +27,6 @@ in
       };
     };
 
-  imports = catppuccinLib.mkRenamedCatppuccinOptions {
-    from = [
-      "programs"
-      "sioyek"
-      "catppuccin"
-    ];
-    to = "sioyek";
-  };
 
   config = lib.mkIf enable {
     xdg.configFile = {

--- a/modules/home-manager/sioyek.nix
+++ b/modules/home-manager/sioyek.nix
@@ -1,0 +1,48 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+
+let
+  inherit (config.catppuccin) sources;
+  
+  cfg = config.catppuccin.sioyek;
+  enable = cfg.enable && config.programs.sioyek.enable;
+  
+  themeFile = "/catppuccin-${cfg.flavor}.config";
+  theme = sources.sioyek + themeFile;
+in
+ 
+{
+  options.catppuccin.sioyek = 
+    catppuccinLib.mkCatppuccinOption {
+      name = "sioyek";
+    }
+    // {
+      applyOnStartup = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Applies the theme by adding `toggle_custom_color` to `startup_commands` in sioyek's config.
+          If this is disabled, you must manually run `toggle_custom_colors` in Sioyek to enable the theme.
+        '';
+      };
+    };
+
+  imports = catppuccinLib.mkRenamedCatppuccinOptions {
+    from = [
+      "programs"
+      "sioyek"
+      "catppuccin"
+    ];
+    to = "sioyek";
+  };
+
+  config = lib.mkIf enable {
+    xdg.configFile = {
+      "sioyek/prefs_user.config".source = theme;
+    };
+    
+    programs.sioyek.config = lib.mkIf cfg.applyOnStartup {
+      startup_commands = lib.mkBefore "toggle_custom_color;";
+    };
+  };
+} 

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -81,6 +81,7 @@
       enable = true;
       syntaxHighlighting.enable = true;
     };
+    sioyak.enable = true;
   };
 
   qt = {

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -81,7 +81,7 @@
       enable = true;
       syntaxHighlighting.enable = true;
     };
-    sioyak.enable = true;
+    sioyek.enable = true;
   };
 
   qt = {

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -199,6 +199,11 @@
     "lastModified": "2025-02-27",
     "rev": "9c0a84c0670ac7cf7e3afc27006455afe492160c"
   },
+  "sioyek": {
+    "hash": "sha256-QlanYqcU/kLJqCceAgIAvXeLJ4y2kMvmzKUYxyCnC/c=",
+    "lastModified": "2024-05-15",
+    "rev": "3e142d195e74c1d61239e0fa2e93347d6fa5eb55"
+  },
   "spotify-player": {
     "hash": "sha256-eenf1jB8b2s2qeG7wAApGwkjJZWVNzQj/wEZMUgnn5U=",
     "lastModified": "2024-08-16",


### PR DESCRIPTION
Hai, I've added a module for sioyak. 
Although I'm not sure what is the best way to handle when `programs.sioyek.config.startup_commands` already has a value.

```shell
error: The option `home-manager.users.n.programs.sioyek.config.startup_commands' has conflicting definition values:
- In `/nix/store/saj8wg1a0iwxynwg2viywh57mfxqbjia-source/modules/home-manager/sioyek.nix': "toggle_custom_color;"
- In `/nix/store/6p5182xf5wbqvrysrraj9kcbm101yjsq-source/home/programs.nix': "toggle_scrollbar"
  Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```