### PR TITLE
flake: `homeModules.default` should not print warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
       ) self.homeModules;
 
       homeModules = {
-        default = self.homeManagerModules.catppuccin;
+        default = self.homeModules.catppuccin;
         catppuccin = mkModule {
           type = "homeManager";
           file = ./modules/home-manager;


### PR DESCRIPTION
It seems pretty established that `default` should stay valid, however when using it, we get the following warning 
```
trace: evaluation warning:
Obsolete Flake attribute `catppuccin.homeManagerModules.catppuccin' is used.
It was renamed to `catppuccin.homeModules.catppuccin`'.
```  