### PR TITLE
fix(paws): use hash instead of narHash

### DIFF
--- a/pkgs/paws.py
+++ b/pkgs/paws.py
@@ -60,7 +60,7 @@ async def handle_port(sources: dict, port: str, remove=False):
 		data = await fetch_port(port)
 		locked = data["locked"]
 		last_modified = datetime.fromtimestamp(int(locked["lastModified"]), tz = timezone.utc).strftime('%Y-%m-%d')
-		sources[port] = {"rev": locked["rev"], "hash": locked["narHash"], "lastModified": last_modified}
+		sources[port] = {"rev": locked["rev"], "hash": data["hash"], "lastModified": last_modified}
 
 
 async def main():


### PR DESCRIPTION
between nix 2.26 and 2.28 theres a difference in the output json from `nix flake prefetch`

nix 2.26: 
```json
{
  "hash": "sha256-JYHsWUKKBzYEc5iSiyYsYm5Kz73PPN0php0JfR9wMxg=",
  "locked": {
    "__final": true,
    "lastModified": 1744992325,
    "narHash": "sha256-JYHsWUKKBzYEc5iSiyYsYm5Kz73PPN0php0JfR9wMxg=",
    "owner": "catppuccin",
    "repo": "atuin",
    "rev": "bd403cf7f0324aafc3f2462aeb9c2be6e230c9ac",
    "type": "github"
  },
  "original": {
    "owner": "catppuccin",
    "repo": "atuin",
    "type": "github"
  },
  "storePath": "/nix/store/0b398ha6q0gbzjswbdxhh8r1fgiyjrgf-source"
}
```

nix 2.18:
```json
{
  "hash": "sha256-JYHsWUKKBzYEc5iSiyYsYm5Kz73PPN0php0JfR9wMxg=",
  "locked": {
    "__final": true,
    "lastModified": 1744992325,
    "owner": "catppuccin",
    "repo": "atuin",
    "rev": "bd403cf7f0324aafc3f2462aeb9c2be6e230c9ac",
    "type": "github"
  },
  "original": {
    "owner": "catppuccin",
    "repo": "atuin",
    "type": "github"
  },
  "storePath": "/nix/store/0b398ha6q0gbzjswbdxhh8r1fgiyjrgf-source"
}
```