### PR TITLE
refactor: zsh-syntax-highlighting initExtra -> initContent

### DIFF
--- a/modules/home-manager/zsh-syntax-highlighting.nix
+++ b/modules/home-manager/zsh-syntax-highlighting.nix
@@ -63,11 +63,16 @@ in
 
     # And this is our actual module
     (lib.mkIf cfg.enable {
-      programs.zsh = {
-        initExtra = lib.mkBefore ''
-          source '${sources.zsh-syntax-highlighting}/catppuccin_${cfg.flavor}-zsh-syntax-highlighting.zsh'
-        '';
-      };
+      programs.zsh =
+        let
+          key = if builtins.hasAttr "initContent" config.programs.zsh then "initContent" else "initExtra";
+        in
+        {
+          # NOTE: Backwards compatible mkOrder priority working with stable/unstable HM.
+          "${key}" = lib.mkOrder (if key == "initContent" then 950 else 500) ''
+            source '${sources.zsh-syntax-highlighting}/catppuccin_${cfg.flavor}-zsh-syntax-highlighting.zsh'
+          '';
+        };
     })
   ];
 }


### PR DESCRIPTION
Will be deprecated shortly, switch to new configuration before users get warnings from it https://github.com/nix-community/home-manager/pull/6841

Using `mkOrder 950` to keep position same in generated output as before. (Top of the `initExtra` location. 