### PR TITLE
feat(home-manager): add support for COSMIC

### DIFF
--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -23,6 +23,14 @@
       inputs.nixpkgs.follows = "nixpkgs-stable";
     };
 
+    cosmic-manager = {
+      url = "github:HeitorAugustoLN/cosmic-manager";
+      inputs = {
+        home-manager.follows = "home-manager";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+
     # Our option search generator
     nuscht-search = {
       url = "github:NuschtOS/search";
@@ -75,8 +83,11 @@
         kernelName = pkgs.stdenv.hostPlatform.parsed.kernel.name;
 
         callWith = pkgs: lib.flip pkgs.callPackage;
-        callUnstable = callWith pkgs { inherit (inputs) home-manager; };
-        callStable = callWith pkgsStable { home-manager = inputs.home-manager-stable; };
+        callUnstable = callWith pkgs { inherit (inputs) home-manager cosmic-manager; };
+        callStable = callWith pkgsStable {
+          inherit (inputs) cosmic-manager;
+          home-manager = inputs.home-manager-stable;
+        };
       in
 
       {

--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -7,6 +7,7 @@
   ./btop.nix
   ./cava.nix
   ./chrome.nix
+  ./cosmic.nix
   ./cursors.nix
   ./delta.nix
   ./dunst.nix

--- a/modules/home-manager/cosmic.nix
+++ b/modules/home-manager/cosmic.nix
@@ -1,0 +1,49 @@
+{ catppuccinLib }:
+{
+  config,
+  cosmicLib,
+  lib,
+  ...
+}:
+let
+  cfg = config.catppuccin;
+in
+{
+  options.catppuccin = {
+    cosmic = catppuccinLib.mkCatppuccinOption {
+      accentSupport = true;
+      name = "cosmic";
+      useGlobalEnable = false;
+    };
+
+    cosmic-term = catppuccinLib.mkCatppuccinOption {
+      name = "cosmic-term";
+      useGlobalEnable = false;
+    };
+  };
+
+  config = lib.mkMerge [
+    {
+      assertions = [
+        {
+          assertion = config._module.args ? cosmicLib;
+          message = "COSMIC Theming requires cosmic-manager module to be available.";
+        }
+      ];
+    }
+
+    (lib.mkIf cfg.cosmic.enable {
+      wayland.desktopManager.cosmic.appearance.theme = {
+        ${if cfg.cosmic.flavor == "latte" then "light" else "dark"} =
+          cosmicLib.cosmic.ron.importRON "${config.catppuccin.sources.cosmic-desktop}/cosmic-settings/catppuccin-${cfg.cosmic.flavor}-${cfg.cosmic.accent}+round.ron";
+        mode = if cfg.cosmic.flavor == "latte" then "light" else "dark";
+      };
+    })
+
+    (lib.mkIf cfg.cosmic-term.enable {
+      programs.cosmic-term.colorSchemes = [
+        (cosmicLib.cosmic.ron.importRON "${config.catppuccin.sources.cosmic-desktop}/cosmic-term/catppuccin-${cfg.cosmic-term.flavor}.ron")
+      ];
+    })
+  ];
+}

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -17,6 +17,11 @@
 
   i18n.inputMethod.enabled = "fcitx5";
 
+  catppuccin = {
+    cosmic.enable = true;
+    cosmic-term.enable = true;
+  };
+
   programs = {
     aerc.enable = true;
     alacritty.enable = true;
@@ -102,6 +107,7 @@
     swaync.enable = true;
   };
 
+  wayland.desktopManager.cosmic.enable = true;
   wayland.windowManager.sway.enable = true;
   wayland.windowManager.hyprland.enable = true;
 }

--- a/modules/tests/nixos.nix
+++ b/modules/tests/nixos.nix
@@ -2,6 +2,7 @@
   lib,
   testers,
   home-manager,
+  cosmic-manager,
 }:
 
 let
@@ -55,6 +56,7 @@ testers.runNixOSTest {
 
       home-manager.users.${userName} = {
         imports = [
+          cosmic-manager.homeManagerModules.default
           ./home.nix
           { home = { inherit (config.system) stateVersion; }; }
         ];

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -34,6 +34,11 @@
     "lastModified": "2024-09-03",
     "rev": "0746f77974330338ee2e1e4d1ef9872eba57eb26"
   },
+  "cosmic-desktop": {
+    "hash": "sha256-NAQnHS+XrMJ/rPgSS5nEQOMBhQtF6mP1i/0QP5arQ64=",
+    "lastModified": "2025-04-22",
+    "rev": "95e81098042dd2102f0b258f6990f886c5759692"
+  },
   "cursors": {
     "hash": "sha256-qis6p+/m7+DdRDYzLq9yB2eZGpfZe5z5xRsa/1HoIG4=",
     "lastModified": "2025-02-22",


### PR DESCRIPTION
Closes #336

Not quite sure if this is the best implementation possible.
It requires [cosmic-manager](https://github.com/HeitorAugustoLN/cosmic-manager) for building the theme, parsing the RON files and writing the files.