### PR TITLE
fix(home-manager/mako): use settings instead of extraConfig

### DIFF
--- a/modules/home-manager/mako.nix
+++ b/modules/home-manager/mako.nix
@@ -35,13 +35,20 @@ in
   };
 
   # Will cause infinite recursion if config.services.mako is directly set as a whole
-  config.services.mako = lib.mkIf cfg.enable {
-    backgroundColor = theme.background-color;
-    textColor = theme.text-color;
-    borderColor = theme.border-color;
-    progressColor = theme.progress-color;
-    extraConfig = lib.fileContents (
-      (pkgs.formats.ini { }).generate "mako-extra-config" extraConfigAttrs
-    );
-  };
+  config.services.mako = lib.mkIf cfg.enable (if (config.services.mako ? settings) then {
+    settings = extraConfigAttrs // {
+      backgroundColor = theme.background-color;
+      textColor = theme.text-color;
+      borderColor = theme.border-color;
+      progressColor = theme.progress-color;
+    };
+  } else {
+      backgroundColor = theme.background-color;
+      textColor = theme.text-color;
+      borderColor = theme.border-color;
+      progressColor = theme.progress-color;
+      extraConfig = lib.fileContents (
+        (pkgs.formats.ini { }).generate "mako-extra-config" extraConfigAttrs
+      );
+  });
 }

--- a/modules/home-manager/mako.nix
+++ b/modules/home-manager/mako.nix
@@ -36,12 +36,13 @@ in
 
   # Will cause infinite recursion if config.services.mako is directly set as a whole
   config.services.mako = lib.mkIf cfg.enable (if (config.services.mako ? settings) then {
-    settings = extraConfigAttrs // {
+    settings = {
       backgroundColor = theme.background-color;
       textColor = theme.text-color;
       borderColor = theme.border-color;
       progressColor = theme.progress-color;
     };
+    criterias = extraConfigAttrs;
   } else {
       backgroundColor = theme.background-color;
       textColor = theme.text-color;

--- a/modules/home-manager/mako.nix
+++ b/modules/home-manager/mako.nix
@@ -42,7 +42,7 @@ in
       borderColor = theme.border-color;
       progressColor = theme.progress-color;
     };
-    criterias = extraConfigAttrs;
+    criteria = extraConfigAttrs;
   } else {
       backgroundColor = theme.background-color;
       textColor = theme.text-color;


### PR DESCRIPTION
fix #552 