### PR TITLE
fix(mako): deprecated settings.criteria

### DIFF
--- a/modules/home-manager/mako.nix
+++ b/modules/home-manager/mako.nix
@@ -38,15 +38,7 @@ in
   config.services.mako = lib.mkIf cfg.enable (
     if (config.services.mako ? settings) then
       {
-        settings = {
-          inherit (theme)
-            background-color
-            text-color
-            border-color
-            progress-color
-            ;
-        };
-        criteria = extraConfigAttrs;
+        settings = theme;
       }
     else
       {


### PR DESCRIPTION
see: https://github.com/nix-community/home-manager/pull/7024
closes https://github.com/catppuccin/nix/issues/564