### PR TITLE
feat(home-manager): add support for vesktop

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -51,6 +51,7 @@
   ./thunderbird.nix
   ./tmux.nix
   ./tofi.nix
+  ./vesktop.nix
   ./vscode.nix
   ./waybar.nix
   ./wezterm.nix

--- a/modules/home-manager/vesktop.nix
+++ b/modules/home-manager/vesktop.nix
@@ -10,11 +10,9 @@ in
   options.catppuccin.vesktop = catppuccinLib.mkCatppuccinOption {
     name = "vesktop";
     accentSupport = true;
-    default = lib.versionAtLeast config.home.stateVersion "25.05" && config.catppuccin.enable;
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = [ (catppuccinLib.assertMinimumVersion "25.05") ];
     programs.vesktop.vencord = {
       settings.enabledThemes = [ "${themeName}.css" ];
       themes."${themeName}" = ''

--- a/modules/home-manager/vesktop.nix
+++ b/modules/home-manager/vesktop.nix
@@ -1,0 +1,33 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+
+let
+  cfg = config.catppuccin.vesktop;
+  themeName = "catppuccin-${cfg.flavor}-${cfg.accent}.theme";
+in
+
+{
+  options.catppuccin.vesktop = catppuccinLib.mkCatppuccinOption {
+    name = "vesktop";
+    accentSupport = true;
+    default = lib.versionAtLeast config.home.stateVersion "25.05" && config.catppuccin.enable;
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [ (catppuccinLib.assertMinimumVersion "25.05") ];
+    programs.vesktop.vencord = {
+      settings.enabledThemes = [ "${themeName}.css" ];
+      themes."${themeName}" = ''
+        /**
+         * @name Catppuccin ${
+           if cfg.flavor == "frappe" then "Frappé" else catppuccinLib.mkUpper cfg.flavor
+         } (${catppuccinLib.mkUpper cfg.accent})
+         * @author Catppuccin
+         * @description 🎮 Soothing pastel theme for Discord
+         * @website https://github.com/catppuccin/discord
+        **/
+        @import url("https://catppuccin.github.io/discord/dist/${themeName}.css");
+      '';
+    };
+  };
+}

--- a/modules/home-manager/vesktop.nix
+++ b/modules/home-manager/vesktop.nix
@@ -17,7 +17,7 @@ in
       settings.enabledThemes = [ "${themeName}.css" ];
       themes."${themeName}" = ''
         /**
-         * @name Catppuccin ${catppuccinLib.mkFlavorName cfg.flavor} (${catppuccinLib.mkUpper cfg.accent})
+         * @name Catppuccin ${catppuccinLib.mkFlavorName cfg.flavor} (${lib.toSentenceCase cfg.accent})
          * @author Catppuccin
          * @description 🎮 Soothing pastel theme for Discord
          * @website https://github.com/catppuccin/discord

--- a/modules/home-manager/vesktop.nix
+++ b/modules/home-manager/vesktop.nix
@@ -19,9 +19,7 @@ in
       settings.enabledThemes = [ "${themeName}.css" ];
       themes."${themeName}" = ''
         /**
-         * @name Catppuccin ${
-           if cfg.flavor == "frappe" then "Frappé" else catppuccinLib.mkUpper cfg.flavor
-         } (${catppuccinLib.mkUpper cfg.accent})
+         * @name Catppuccin ${catppuccinLib.mkFlavorName cfg.flavor} (${catppuccinLib.mkUpper cfg.accent})
          * @author Catppuccin
          * @description 🎮 Soothing pastel theme for Discord
          * @website https://github.com/catppuccin/discord

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -76,6 +76,7 @@
       enable = true;
       profiles.catppuccin-mocha-mauve.isDefault = true;
     };
+    vesktop.enable = true;
     vscode = {
       enable = true;
       package = pkgs.vscodium;


### PR DESCRIPTION
[catppuccin/discord](https://github.com/catppuccin/discord) mainly uses GitHub dists for the discord themes.

I don't see a reason to include it in sources. The only themes that will be generated are flavor-only themes [(example)](https://github.com/catppuccin/discord/blob/main/themes/mocha.theme.css) and those don't do more than importing the dist file.

So I decided to import the theme directly.
If you have any suggestions, let me know.