### PR TITLE
chore: update gitea package to v1.0.2

### DIFF
--- a/pkgs/gitea/package.nix
+++ b/pkgs/gitea/package.nix
@@ -1,6 +1,6 @@
 { fetchzip }:
 fetchzip {
-  url = "https://github.com/catppuccin/gitea/releases/download/v0.4.1/catppuccin-gitea.tar.gz";
-  hash = "sha256-14XqO1ZhhPS7VDBSzqW55kh6n5cFZGZmvRCtMEh8JPI=";
+  url = "https://github.com/catppuccin/gitea/releases/download/v1.0.2/catppuccin-gitea.tar.gz";
+  hash = "sha256-rZHLORwLUfIFcB6K9yhrzr+UwdPNQVSadsw6rg8Q7gs=";
   stripRoot = false;
 }


### PR DESCRIPTION
The `gitea` package seems to be out of sync with the most recent release from `catppuccin/gitea` https://github.com/catppuccin/gitea/releases/tag/v1.0.2