### PR TITLE
feat(nixos): Add support for Limine

### DIFF
--- a/modules/nixos/all-modules.nix
+++ b/modules/nixos/all-modules.nix
@@ -2,6 +2,7 @@
   ./fcitx5.nix
   ./gitea.nix
   ./grub.nix
+  ./limine.nix
   ./plymouth.nix
   ./sddm.nix
   ./tty.nix

--- a/modules/nixos/limine.nix
+++ b/modules/nixos/limine.nix
@@ -1,0 +1,25 @@
+{ catppuccinLib }:
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  inherit (config.catppuccin) sources;
+
+  cfg = config.catppuccin.limine;
+
+  theme = sources.limine + "/catppuccin-${cfg.flavor}.conf";
+in
+
+{
+  options.catppuccin.limine = catppuccinLib.mkCatppuccinOption { name = "limine"; };
+
+  config = lib.mkIf cfg.enable {
+    boot.loader.limine = {
+      extraConfig = lib.fileContents theme;
+      style.wallpapers = [ ];
+    };
+  };
+}

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -129,6 +129,11 @@
     "lastModified": "2025-04-21",
     "rev": "c24895902ec2a3cb62b4557f6ecd8e0afeed95d5"
   },
+  "limine": {
+    "hash": "sha256-CdL1fq7JKju5SOvt8pBynLzM1knlM26SRinqYD48b+c=",
+    "lastModified": "2024-08-04",
+    "rev": "87a6320b8385c2745468eeff925c57a223200085"
+  },
   "lsd": {
     "hash": "sha256-lf6VawCgK9VlKO+PAzPD/WqPjxoqw2j000b5ZlEXj/Y=",
     "lastModified": "2024-11-28",


### PR DESCRIPTION
Adds the upstream style config as a nixos module, configurable by the overarching flavor setting.

As it is configured currently, it overrides the wallpaper options, because nixpkgs ships with a default one. If there is a better solution for this, please feel free to submit a review message.

Closes #571 