### PR TITLE
refactor: add `lib.mkFlavorName`

### DIFF
--- a/modules/home-manager/vscode.nix
+++ b/modules/home-manager/vscode.nix
@@ -15,8 +15,7 @@ let
     extensions = [ (sources.vscode.override { catppuccinOptions = cfg.settings; }) ];
 
     userSettings = {
-      "workbench.colorTheme" =
-        "Catppuccin " + (if cfg.flavor == "frappe" then "Frappé" else catppuccinLib.mkUpper cfg.flavor);
+      "workbench.colorTheme" = "Catppuccin " + (catppuccinLib.mkFlavorName cfg.flavor);
       "catppuccin.accentColor" = cfg.accent;
 
       # Recommended settings

--- a/modules/home-manager/zed-editor.nix
+++ b/modules/home-manager/zed-editor.nix
@@ -7,10 +7,8 @@ let
   cfg = config.catppuccin.zed;
   enable = cfg.enable && config.programs.zed-editor.enable;
 
-  fl = fl: if fl == "frappe" then "Frappé" else catppuccinLib.mkUpper fl;
-
   accent = if cfg.accent == "mauve" then "" else " (${cfg.accent})";
-  flavor = fl cfg.flavor;
+  flavor = catppuccinLib.mkFlavorName cfg.flavor;
 in
 
 {
@@ -33,7 +31,9 @@ in
     programs.zed-editor = {
       extensions = lib.optionals cfg.icons.enable [ "catppuccin-icons" ];
       userSettings = {
-        icon_theme = lib.mkIf cfg.icons.enable ("Catppuccin " + (fl cfg.icons.flavor));
+        icon_theme = lib.mkIf cfg.icons.enable (
+          "Catppuccin " + (catppuccinLib.mkFlavorName cfg.icons.flavor)
+        );
         theme = {
           light = "Catppuccin " + flavor + accent + lib.optionalString (!cfg.italics) " - No Italics";
           dark = "Catppuccin " + flavor + accent + lib.optionalString (!cfg.italics) " - No Italics";

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -79,6 +79,29 @@ lib.makeExtensible (ctp: {
   mkUpper = str: (toUpper (substring 0 1 str)) + (substring 1 (stringLength str) str);
 
   /**
+    Capitalize the first letter in a string, and change the final "e" into "é" if the
+    original string is "frappe"
+
+    # Example
+
+    ```nix
+    mkFlavorName "frappe"
+    => "Frappé"
+    ```
+
+    # Type
+
+    ```
+    mkFlavorName :: String -> String
+    ```
+
+    # Arguments
+
+    - [str] String to capitalize
+  */
+  mkFlavorName = str: if str == "frappe" then "Frappé" else ctp.mkUpper str;
+
+  /**
     Reads a YAML file
 
     # Example


### PR DESCRIPTION
This transformation is used in a few places, so it would be nice to have a common library function for it. (Also would be useful for end users as part of a public `lib` interface, if that's on the table.)
