### PR TITLE
feat(home-manager): add userstyle support for firefox-based browsers

### DIFF
--- a/pkgs/build-stylus-settings/package.nix
+++ b/pkgs/build-stylus-settings/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchurl,
+}:
+let
+  stylusSectionsUtil = fetchurl {
+    url = "https://raw.githubusercontent.com/openstyles/stylus/8fe35a4b90d85fb911bd7aa1deab4e4733c31150/src/js/sections-util.js";
+    hash = "sha256-OH4WStQLx2BI3MqvzmoDKsdFYW5/wp8Yc9faM/VzlQI=";
+  };
+
+  usercssMetaTypes = fetchurl {
+    url = "https://raw.githubusercontent.com/catppuccin/userstyles/714b153c7022c362a37ab8530286a87e4484a828/scripts/types/usercss-meta.d.ts";
+    hash = "sha256-e/gazaMzr0WcarsE/NqCVT/iCG9CoB0lnZiOr1l19Jk=";
+  };
+in
+buildNpmPackage (finalAttrs: {
+  pname = "build-stylus-settings";
+  version = "0.2.0";
+
+  src = lib.cleanSource ./src;
+
+  prePatch = ''
+    cp ${stylusSectionsUtil} ./scripts/sections-util.js
+    cp ${usercssMetaTypes} ./scripts/usercss-meta.d.ts
+  '';
+
+  patches = [
+    ./usercss-meta-stringify-type.patch
+  ];
+
+  npmDepsHash = "sha256-YshVeiUTXueFW8yDA/kOfYR0jUW+f6+5bdzinbGvo+g=";
+
+  meta = {
+    description = "Stylus storage.js file generator, compatible with Catppuccin Userstyles";
+    license = lib.licenses.mit;
+    mainProgram = "build-stylus-settings";
+    maintainers = with lib.maintainers; [
+      getchoo
+      isabelroses
+    ];
+  };
+})

--- a/pkgs/build-stylus-settings/src/package-lock.json
+++ b/pkgs/build-stylus-settings/src/package-lock.json
@@ -1,0 +1,528 @@
+{
+  "name": "build-stylus-settings",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "build-stylus-settings",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "less": "^4.3.0",
+        "parserlib": "^1.1.1",
+        "postcss": "^8.5.6",
+        "usercss-meta": "^0.12.0",
+        "yargs": "^18.0.0",
+        "zod": "^3.25.69"
+      },
+      "bin": {
+        "build-stylus-settings": "dist/main.js"
+      },
+      "devDependencies": {
+        "@types/less": "^3.0.8",
+        "@types/node": "^20.0.0",
+        "@types/yargs": "^17.0.33",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@types/less": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/less/-/less-3.0.8.tgz",
+      "integrity": "sha512-Gjm4+H9noDJgu5EdT3rUw5MhPBag46fiOy27BefvWkNL8mlZnKnCaVVVTLKj6RYXed9b62CPKnPav9govyQDzA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
+      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.6.tgz",
+      "integrity": "sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^3.14.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
+    },
+    "node_modules/errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
+      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
+      "license": "MIT"
+    },
+    "node_modules/less": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.3.0.tgz",
+      "integrity": "sha512-X9RyH9fvemArzfdP8Pi3irr7lor2Ok4rOttDXBhlwDg+wKQsXOXgHWduAJE1EsF7JJx0w0bcO6BC6tCKKYnXKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "copy-anything": "^2.0.1",
+        "parse-node-version": "^1.0.1",
+        "tslib": "^2.3.0"
+      },
+      "bin": {
+        "lessc": "bin/lessc"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "make-dir": "^2.1.0",
+        "mime": "^1.4.1",
+        "needle": "^3.1.0",
+        "source-map": "~0.6.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/needle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
+      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/parse-node-version": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/parserlib": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parserlib/-/parserlib-1.1.1.tgz",
+      "integrity": "sha512-e1HbF3+7ASJ/uOZirg5/8ZfPljTh100auNterbHB8TUs5egciuWQ2eX/2al8ko0RdV9Xh/5jDei3jqJAmbTDcg==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/usercss-meta": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/usercss-meta/-/usercss-meta-0.12.0.tgz",
+      "integrity": "sha512-zKrXCKdpeIwtVe87omxGo9URf+7mbozduMZEg79dmT4KB3XJwfIkEi/Uk0PcTwR/nZLtAK1+k7isgbGB/g6E7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.69",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.69.tgz",
+      "integrity": "sha512-cjUx+boz8dfYGssYKLGNTF5VUF6NETpcZCDTN3knhUUXQTAAvErzRhV3pgeCZm2YsL4HOwtEHPonlsshPu2I0A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/pkgs/build-stylus-settings/src/package.json
+++ b/pkgs/build-stylus-settings/src/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "build-stylus-settings",
+  "version": "0.2.0",
+  "description": "Stylus storage.js file generator, compatible with Catppuccin Userstyles",
+  "homepage": "https://github.com/different-name/catppuccin-userstyles-nix#readme",
+  "bugs": {
+    "url": "https://github.com/different-name/catppuccin-userstyles-nix/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/different-name/catppuccin-userstyles-nix.git"
+  },
+  "license": "MIT",
+  "author": "different-name",
+  "type": "module",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc && cp scripts/sections-util.js dist/",
+    "start": "node dist/main.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "bin": {
+    "build-stylus-settings": "dist/main.js"
+  },
+  "devDependencies": {
+    "@types/less": "^3.0.8",
+    "@types/node": "^20.0.0",
+    "@types/yargs": "^17.0.33",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "less": "^4.3.0",
+    "parserlib": "^1.1.1",
+    "postcss": "^8.5.6",
+    "usercss-meta": "^0.12.0",
+    "yargs": "^18.0.0",
+    "zod": "^3.25.69"
+  }
+}

--- a/pkgs/build-stylus-settings/src/scripts/inputs.ts
+++ b/pkgs/build-stylus-settings/src/scripts/inputs.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { UserstylesConfigManager } from './userstyles-config-manager.js';
+
+const positionalArgsSchema = z.tuple([
+  z.string().nonempty(),
+  z.string().nonempty().optional()
+]);
+
+// this is catppuccin specific, it would be nice to make this generic
+// adapted from https://github.com/catppuccin/userstyles/blob/11fd3b1c875a46b765ad5a4f8b4716b0df0d1624/scripts/utils.ts#L153C1-L162C2
+async function getUserstylesFiles(stylesPath: string) {
+  const files: string[] = [];
+  const stylesDir = await readdir(stylesPath, { withFileTypes: true });
+  for (const dir of stylesDir) {
+    if (!dir.isDirectory) continue;
+    files.push(
+      path.join(stylesPath, dir.name, "catppuccin.user.less"),
+    );
+  }
+  return files;
+}
+
+export async function loadInputs() {
+  const argv = yargs(hideBin(process.argv))
+    .usage('Usage: $0 <styles_path> [config_path]')
+    .demandCommand(1)
+    .parseSync();
+
+  const [stylesPath, configPath] = positionalArgsSchema.parse(argv._);
+
+  const userstylesFiles = await getUserstylesFiles(stylesPath);
+  const userstyles = await Promise.all(
+    userstylesFiles.map(userstyle => readFile(userstyle, 'utf-8'))
+  );
+
+  const configString = configPath ? await readFile(configPath, 'utf-8') : '{}';
+  const rawConfig = JSON.parse(configString);
+  const config = new UserstylesConfigManager(rawConfig);
+
+  return { userstyles, config };
+}

--- a/pkgs/build-stylus-settings/src/scripts/main.ts
+++ b/pkgs/build-stylus-settings/src/scripts/main.ts
@@ -1,0 +1,62 @@
+import { loadInputs } from './inputs.js';
+import { parseMeta, stringifyMeta } from './metadata.js';
+import less from 'less';
+import { generateStylusSections } from './sections.js';
+import { calcStyleDigest } from './sections-util.js';
+import { writeFile } from 'node:fs/promises';
+
+async function main() {
+  const { userstyles, config } = await loadInputs();
+
+  const stylusStorage: Record<string, unknown> = {
+    // required for stylus to continue to use storage.js file
+    dbInChromeStorage: true,
+  };
+
+  for (const [index, userstyle] of userstyles.entries()) {
+    const metadata = parseMeta(userstyle);
+
+    if (!config.isEnabled(metadata.name)) continue;
+
+    const bakedVars = Object.values(metadata.vars ?? {}).map((setting) => {
+      let value = config.getSetting(metadata.name, setting.name, setting.default);
+      if (typeof value === 'boolean') value = (+ value);
+      return `@${setting.name}: ${value};`;
+    }).join('\n');
+
+    delete metadata.vars;
+    delete metadata.updateURL;
+
+    const bakedUserstyle = `
+      ${stringifyMeta(metadata)}
+      ${bakedVars}
+      ${userstyle.replace(/\/\*[\s\S]*?\*\//, '')}
+    `;
+
+    const compiledUserstyle = (await less.render(bakedUserstyle)).css;
+
+    const stylusUserstyle: Record<string, unknown> = {
+      enabled: true,
+      name: metadata.name,
+      description: metadata.description,
+      author: metadata.author,
+      url: metadata.url,
+      usercssData: metadata,
+      sourceCode: bakedUserstyle,
+      sections: generateStylusSections(compiledUserstyle),
+      _id: crypto.randomUUID(),
+      _rev: Date.now(),
+      id: index + 1,
+      inclusions: config.getProperty(metadata.name, 'inclusions'),
+      exclusions: config.getProperty(metadata.name, 'exclusions')
+    };
+
+    stylusUserstyle.originalDigest = await calcStyleDigest(userstyle);
+
+    stylusStorage[`style-${index + 1}`] = stylusUserstyle;
+  }
+
+  writeFile("storage.js", JSON.stringify(stylusStorage));
+}
+
+await main();

--- a/pkgs/build-stylus-settings/src/scripts/metadata.ts
+++ b/pkgs/build-stylus-settings/src/scripts/metadata.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import usercssMeta from 'usercss-meta';
+
+// The format that the script expects metadata to be in
+const metadataSchema = z.object({
+  name: z.string().nonempty(),
+  description: z.string().optional(),
+  author: z.string().optional(),
+  vars: z.record(z.object({
+    name: z.string().nonempty(),
+    default: z.union([z.string().nonempty(), z.number()]).optional()
+  })).optional(),
+  url: z.string().optional(),
+}).catchall(z.unknown());
+
+type Metadata = z.infer<typeof metadataSchema>;
+
+export function parseMeta(usersyle: string) {
+  const { metadata } = usercssMeta.parse(usersyle);
+  return metadataSchema.parse(metadata);
+}
+
+export function stringifyMeta(metadata: Metadata) {
+  return usercssMeta.stringify(metadata as unknown as usercssMeta.Metadata, {});
+}
+

--- a/pkgs/build-stylus-settings/src/scripts/sections-util.d.ts
+++ b/pkgs/build-stylus-settings/src/scripts/sections-util.d.ts
@@ -1,0 +1,1 @@
+export function calcStyleDigest(userstyle: unknown): Promise<string>;

--- a/pkgs/build-stylus-settings/src/scripts/sections.ts
+++ b/pkgs/build-stylus-settings/src/scripts/sections.ts
@@ -1,0 +1,67 @@
+import postcss from 'postcss';
+
+/*
+  This entire file, along with the preprocessing steps in main.ts
+  could probably be replaced by stylus/src/js/usercss-compiler.js:
+  https://github.com/openstyles/stylus/blob/e9eb9fcea9c336dd1cec9c2c8c8e3b0f05d7b733/src/js/usercss-compiler.js#L111
+*/
+
+type SectionMatchType = 'domains' | 'regexps' | 'urlPrefixes';
+
+type Section = {
+  code: string,
+  start: number,
+} & Partial<Record<SectionMatchType, string[]>>;
+
+export function generateStylusSections(css: string) {
+  const cssRoot = postcss.parse(css);
+  const sections: Section[] = []
+
+  cssRoot.walkAtRules('-moz-document', (rule: postcss.AtRule) => {
+    const content = rule.nodes?.map(n => n.toString()).join('\n') ?? '';
+
+    const section: Section = {
+      code: content,
+      start: sections.map(s => s.code).join('\n').length
+    };
+
+    const matchTypeMapping: Record<string, SectionMatchType> = {
+      domain: "domains",
+      regexp: "regexps",
+      "url-prefix": "urlPrefixes"
+    };
+
+    const conditions = rule.params?.split(', ') ?? [];
+    conditions.forEach(condition => {
+      // match condition name and argument
+      // e.g. for domain("docs.github.com"):
+      // match[0] domain("docs.github.com")
+      // match[1] domain
+      // match[2] docs.github.com
+      const match = condition.match(/^([\w-]+)\("(.+)"\)$/);
+      if (!match) throw new Error(`Could not parse condition name from '${condition}'`);
+
+      const conditionName = match[1];
+      const conditionArgument = match[2].replace(/\\\\/g, "\\"); // Remove extra level of escaping
+
+      if (!(conditionName in matchTypeMapping)) {
+        throw new Error(`Unknown condition name '${conditionName}'`);
+      }
+
+      const stylusRule = matchTypeMapping[conditionName];
+
+      if (!Array.isArray(section[stylusRule])) section[stylusRule] = [];
+      section[stylusRule].push(conditionArgument);
+    })
+
+    sections.push(section);
+    rule.remove();
+  });
+
+  cssRoot.walkComments(comment => { comment.remove() });
+
+  const unhandledCss = cssRoot.toString().trim();
+  if (unhandledCss) throw new Error(`Unhandled CSS: ${unhandledCss}`);
+
+  return sections;
+}

--- a/pkgs/build-stylus-settings/src/scripts/userstyles-config-manager.ts
+++ b/pkgs/build-stylus-settings/src/scripts/userstyles-config-manager.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+const UserstyleSettingSchema = z.union([
+  z.string(), z.number(), z.boolean()
+]);
+
+const UserstyleSettingsSchema = z.record(UserstyleSettingSchema);
+
+const UserstyleConfigSchema = z.record(z.object({
+  enable: z.boolean().optional(),
+  settings: UserstyleSettingsSchema.optional(),
+  inclusions: z.array(z.string()).optional(),
+  exclusions: z.array(z.string()).optional()
+}));
+
+const UserstylesConfigSchema = z.object({
+  defaultSettings: UserstyleSettingsSchema.optional(),
+  userstyles: UserstyleConfigSchema.optional()
+});
+
+type UserstyleSetting = z.infer<typeof UserstyleSettingSchema>;
+type UserstyleConfig = z.infer<typeof UserstyleConfigSchema>;
+type UserstylesConfig = z.infer<typeof UserstylesConfigSchema>;
+type UserstyleProperty = keyof UserstyleConfig[string];
+
+export class UserstylesConfigManager {
+  private readonly config: UserstylesConfig;
+
+  constructor(rawConfig: any) {
+    const config = UserstylesConfigSchema.parse(rawConfig);
+
+    // Normalize userstyle keys to lowercase
+    const lowercaseUserstyles: UserstyleConfig = {};
+    for (const key in config.userstyles) {
+      lowercaseUserstyles[key.toLowerCase()] = config.userstyles[key];
+    }
+    this.config = {
+      ...config,
+      userstyles: lowercaseUserstyles
+    };
+  }
+
+  public isEnabled(userstyleName: string) {
+    const key = userstyleName.toLowerCase();
+    const enabled = this.config.userstyles?.[key]?.enable;
+    // We do want to return true for undefined values
+    return enabled !== false;
+  }
+
+  public getProperty(userstyleName: string, property: UserstyleProperty) {
+    const key = userstyleName.toLowerCase();
+    return this.config.userstyles?.[key]?.[property];
+  }
+
+  public getSetting(userstyleName: string, setting: string, fallback: UserstyleSetting | undefined): UserstyleSetting {
+    const key = userstyleName.toLowerCase();
+    const value = this.config.userstyles?.[key]?.settings?.[setting] // from userstyle settings
+      ?? this.config.defaultSettings?.[setting]; // from default settings
+    if (value !== undefined) return value;
+    if (fallback !== undefined) return fallback;
+    throw new Error(`Could not find value for "${userstyleName}"."${setting}"`);
+  }
+}

--- a/pkgs/build-stylus-settings/src/tsconfig.json
+++ b/pkgs/build-stylus-settings/src/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "nodenext",
+    "target": "es2020",
+    "module": "nodenext",
+    "lib": [
+      "es2020"
+    ],
+    "outDir": "dist",
+    "rootDir": "scripts",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+  },
+  "include": [
+    "scripts"
+  ]
+}

--- a/pkgs/build-stylus-settings/usercss-meta-stringify-type.patch
+++ b/pkgs/build-stylus-settings/usercss-meta-stringify-type.patch
@@ -1,0 +1,17 @@
+--- a/scripts/usercss-meta.d.ts
++++ b/scripts/usercss-meta.d.ts
+@@ -63,10 +63,10 @@ declare namespace usercssMeta {
+   export function createParser(options?: ParserOptions): Parser;
+
+   // TODO: export stringify types
+-  // export function stringify(
+-  //   metadata: Metadata,
+-  //   options: StringifierOptions,
+-  // ): string;
++  export function stringify(
++    metadata: Metadata,
++    options: StringifierOptions,
++  ): string;
+   // export function createStringifier(options: StringifierOptions): Stringifier;
+
+   type Parser = {

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -264,6 +264,11 @@
     "lastModified": "2024-05-17",
     "rev": "d6106461867c077a5e1d25236e02b7be7c83839e"
   },
+  "userstyles": {
+    "hash": "sha256-pA763sur96Z54DqJkLQmBFPtTnmm09ZSpUGpTRnG2IM=",
+    "lastModified": "2025-07-29",
+    "rev": "05b7f38ae81223fab713f8ddbafa108f92832b68"
+  },
   "waybar": {
     "hash": "sha256-za0y6hcN2rvN6Xjf31xLRe4PP0YyHu2i454ZPjr+lWA=",
     "lastModified": "2024-07-13",

--- a/pkgs/userstyles/package.nix
+++ b/pkgs/userstyles/package.nix
@@ -1,0 +1,23 @@
+{
+  buildCatppuccinPort,
+  build-stylus-settings,
+  userstylesConfig ? { },
+}:
+let
+  userstylesOptionsFile = builtins.toFile "catppuccin-userstyles-options" (
+    builtins.toJSON userstylesConfig
+  );
+in
+buildCatppuccinPort {
+  port = "userstyles";
+
+  nativeBuildInputs = [
+    build-stylus-settings
+  ];
+
+  buildPhase = ''
+    mkdir -p $out/share ./deno_cache
+    DENO_DIR=$PWD/deno_cache build-stylus-settings "$src/styles" "${userstylesOptionsFile}"
+    cp storage.js $out/share/
+  '';
+}


### PR DESCRIPTION
@isabelroses I spent the day today implementing [catppuccin-userstyles-nix](https://github.com/different-name/catppuccin-userstyles-nix) as a catppuccin/nix module

This adds userstyle (Stylus) support for Firefox based browsers supported by Home Manager's mkFirefoxModule helper (`firefox`, `librewolf` & `floorp`)

This falls under the option set

```
catppucin.<browser>.profiles.<profile>.userstyles
```

This allows for per profile configuration

Everything is under the `userstyles` option to allow for separate Firefox Color configuration options under the `theme` option (see #592)

Individual userstyles options can also be configured, for example:

```nix
catppuccin.firefox.profiles.default.userstyles = {
  # Configure individual userstyles
  settings = {
    youtube = {
      lightFlavor = "latte";
      darkFlavor = "mocha";
      accentColor = "mauve";

      logo = true;
      oled = false;
      sponsorBlock = true;
    };

    # Remove GitHub userstyle
    github.enable = false;
  };
};
```

Stylus must currently be installed by the user manually, but we have two other options for this: we could package and install Stylus ourselves, or do what [Stylix does with Firefox Color and use NUR](https://github.com/nix-community/stylix/blob/4ead8043f70cc3b951e704a1f6e40c8a10230e61/modules/firefox/each-config.nix#L104)