### PR TITLE
feat(home-manager): add theme support for firefox-based browsers

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -11,6 +11,7 @@
   ./delta.nix
   ./dunst.nix
   ./fcitx5.nix
+  ./firefox.nix
   ./fish.nix
   ./foot.nix
   ./freetube.nix

--- a/modules/home-manager/firefox.nix
+++ b/modules/home-manager/firefox.nix
@@ -1,0 +1,83 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+let
+  inherit (lib)
+    importJSON
+    mapAttrs
+    toSentenceCase
+    mkIf
+    mkOption
+    getAttrFromPath
+    setAttrByPath
+    types
+    ;
+
+  inherit (config.catppuccin) sources;
+  themes = importJSON "${sources.firefox}/themes.json";
+
+  mkFirefoxModule =
+    {
+      name,
+      prettyName ? toSentenceCase name,
+      hmModulePath ? [
+        "programs"
+        name
+      ],
+    }:
+    let
+      modulePath = [
+        "catppuccin"
+        name
+      ];
+      cfg = getAttrFromPath modulePath config;
+    in
+    {
+      options = setAttrByPath modulePath {
+        profiles = mkOption {
+          type = types.attrsOf (
+            types.submodule {
+              options =
+                catppuccinLib.mkCatppuccinOption {
+                  inherit name;
+                  accentSupport = true;
+                }
+                // {
+                  force = mkOption {
+                    type = types.bool;
+                    default = false;
+                    description = "Forcibly override any existing configuration for Firefox Color.";
+                    example = true;
+                  };
+                };
+            }
+          );
+          default = { };
+          description = "Catppuccin settings for ${prettyName} profiles.";
+        };
+      };
+
+      config = setAttrByPath hmModulePath {
+        profiles = mapAttrs (_: profile: {
+          extensions = {
+            settings."FirefoxColor@mozilla.com" = mkIf profile.enable {
+              inherit (profile) force;
+              settings = {
+                firstRunDone = true;
+                theme = themes.${profile.flavor}.${profile.accent};
+              };
+            };
+          };
+        }) cfg.profiles;
+      };
+    };
+in
+{
+  imports = map mkFirefoxModule [
+    { name = "firefox"; }
+    {
+      name = "librewolf";
+      prettyName = "LibreWolf"; # W in LibreWolf is uppercase
+    }
+    { name = "floorp"; }
+  ];
+}

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -17,6 +17,12 @@
 
   i18n.inputMethod.enabled = "fcitx5";
 
+  catppuccin = {
+    firefox.profiles.test = { };
+    librewolf.profiles.test = { };
+    floorp.profiles.test = { };
+  };
+
   programs = {
     aerc.enable = true;
     alacritty.enable = true;

--- a/pkgs/firefox/package.nix
+++ b/pkgs/firefox/package.nix
@@ -1,0 +1,33 @@
+{
+  buildCatppuccinPort,
+  fetchYarnDeps,
+  sources,
+  yarnConfigHook,
+  yarnBuildHook,
+  nodejs,
+}:
+buildCatppuccinPort {
+  port = "firefox";
+
+  patches = [
+    ./write-themes-to-json.patch
+  ];
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = sources.firefox + /yarn.lock;
+    hash = "sha256-EWx1/kujC6HBSJr6d4sTlFwANbZqBQ3FHetHcbMtiVU=";
+  };
+
+  yarnBuildScript = "generate";
+
+  installPhase = ''
+    mkdir -p $out
+    cp themes.json $out
+  '';
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+  ];
+}

--- a/pkgs/firefox/write-themes-to-json.patch
+++ b/pkgs/firefox/write-themes-to-json.patch
@@ -1,0 +1,45 @@
+diff --git a/main.js b/main.js
+index a4b6e93..42c1824 100644
+--- a/main.js
++++ b/main.js
+@@ -1,5 +1,6 @@
+ import JsonUrl from "json-url";
+ import { variants } from "@catppuccin/palette";
++import { writeFileSync } from "node:fs";
+ 
+ const accents = [
+     "rosewater",
+@@ -37,6 +38,8 @@ const capitalize = (s) => {
+ };
+ 
+ (async () => {
++    let themes = {};
++
+     for (const flavour of Object.keys(variants)) {
+         console.log(`<details>\n<summary>${capitalize(flavour)}</summary>\n`);
+         const lib = {};
+@@ -51,6 +54,8 @@ const capitalize = (s) => {
+             };
+         });
+ 
++        themes[flavour] = {};
++
+         for (const accent of accents) {
+             lib.accent = lib[accent];
+ 
+@@ -99,6 +104,8 @@ const capitalize = (s) => {
+                 title: `Catppuccin ${flavour} ${accent}`,
+             };
+ 
++            themes[flavour][accent] = theme;
++
+             const url = await jsonCodec.compress(theme);
+             const link = `<a href="https://color.firefox.com/?theme=${url}">${capitalize(
+                 accent
+@@ -108,4 +115,6 @@ const capitalize = (s) => {
+         }
+         console.log(`</details>`);
+     }
++
++    writeFileSync("themes.json", JSON.stringify(themes));
+ })();

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -54,6 +54,11 @@
     "lastModified": "2025-05-16",
     "rev": "393845cf3ed0e0000bfe57fe1b9ad75748e2547f"
   },
+  "firefox": {
+    "hash": "sha256-8yZA3Amus00xORmxDJxgKmbH4zou+OpMfSYV7vMS4P8=",
+    "lastModified": "2023-07-18",
+    "rev": "1aa345a3312f0a649068418679ceb81a9c599d36"
+  },
   "fish": {
     "hash": "sha256-Oc0emnIUI4LV7QJLs4B2/FQtCFewRFVp7EDv8GawFsA=",
     "lastModified": "2025-03-01",


### PR DESCRIPTION
Supersedes #451

Opening a new PR as #451 hasn't seen activity in a few months and I took this in a different direction

This adds Firefox Color support for Firefox based browsers supported by Home Manager's mkFirefoxModule helper (`firefox`, `librewolf` & `floorp`)

This uses a different option path to the previous PR, allowing for per-profile config

```
catppucin.<browser>.profiles.<profile>.theme
```

~~Everything is under the `theme` option to allow for seperate userstyle configuration options under the `userstyles` option (see #591)~~

Some considerations:

Firefox Color must currently be installed by the user manually, but we have two other options for this: we could package and install Firefox Color ourselves, or do what [Stylix does and use NUR](https://github.com/nix-community/stylix/blob/4ead8043f70cc3b951e704a1f6e40c8a10230e61/modules/firefox/each-config.nix#L104)

Firefox Color seems to have a bug where there the theme is not applied instantly on startup, I found a few posts about this, but no tracked issues. But this is upstream, and isn't a problem with the module