### PR TITLE
feat(home-manager): add support for mangohud

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -35,6 +35,7 @@
   ./newsboat.nix
   ./nushell.nix
   ./mako.nix
+  ./mangohud.nix
   ./micro.nix
   ./mpv.nix
   ./neovim.nix

--- a/modules/home-manager/mangohud.nix
+++ b/modules/home-manager/mangohud.nix
@@ -1,0 +1,17 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+
+let
+  inherit (config.catppuccin) sources;
+  cfg = config.catppuccin.mangohud;
+in
+
+{
+  options.catppuccin.mangohud = catppuccinLib.mkCatppuccinOption { name = "mangohud"; };
+
+  config = lib.mkIf cfg.enable {
+    xdg.configFile = lib.mkIf config.programs.mangohud.enable {
+      "MangoHud/MangoHud.conf".source = "${sources.mangohud}/${cfg.flavor}/MangoHud.conf";
+    };
+  };
+}

--- a/modules/tests/darwin.nix
+++ b/modules/tests/darwin.nix
@@ -31,6 +31,7 @@
           ghostty.enable = lib.mkVMOverride false; # TODO: Remove when Darwin support is added
           hyprlock.enable = lib.mkVMOverride false;
           imv.enable = lib.mkVMOverride false;
+          mangohud.enable = lib.mkVMOverride false;
           mpv.enable = lib.mkVMOverride false; # NOTE: same as cava, but `mpv` fails to build currently
           obs-studio.enable = lib.mkVMOverride false;
           rio.enable = lib.mkVMOverride false; # marked as broken

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -59,6 +59,7 @@
     kitty.enable = true;
     lazygit.enable = true;
     lsd.enable = true;
+    mangohud.enable = true;
     micro.enable = true;
     mpv.enable = true;
     neovim.enable = true;

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -154,6 +154,11 @@
     "lastModified": "2024-08-30",
     "rev": "92844f144e72f2dc8727879ec141ffdacf3ff6a1"
   },
+  "mangohud": {
+    "hash": "sha256-t3BibbcC8EAk8/Z+xjmZXaaiSIGlFtIGYhL0G+A84Io=",
+    "lastModified": "2025-06-11",
+    "rev": "9d4a3adc3dea2082831eeea00a7c1f5c68488f90"
+  },
   "micro": {
     "hash": "sha256-+Jf32S2CHackdmx+UmEKjx71ZCf4VfnxeA3yzz3MSLQ=",
     "lastModified": "2024-09-08",


### PR DESCRIPTION
Hello,

I've added support for mangohud.

Home-Manager provides a mangohud module and a settings option for it, but we can't import the config file like we do with toml, json or ini.

MangoHud doesn't have an include/import option in the MangoHud config, so we must replace the whole config.
There is an option called preset, but this didn't feel right either.

If you have any suggestions or don't like this solution, please let me know.

Have a great day!