### PR TITLE
feat(home-manager/cursors): support global enable

### DIFF
--- a/modules/home-manager/cursors.nix
+++ b/modules/home-manager/cursors.nix
@@ -1,6 +1,7 @@
 { catppuccinLib }:
 {
   config,
+  pkgs,
   lib,
   ...
 }:
@@ -23,9 +24,7 @@ in
   options.catppuccin.cursors =
     catppuccinLib.mkCatppuccinOption {
       name = "pointer cursors";
-      # NOTE: We exclude this as there is no `enable` option in the upstream
-      # module to guard it
-      useGlobalEnable = false;
+      useGlobalEnable = pkgs.stdenv.hostPlatform.isLinux;
     }
     // {
       accent = lib.mkOption {


### PR DESCRIPTION
i forgot i did this upstream: https://github.com/nix-community/home-manager/pull/6492