### PR TITLE
refactor(home-manager/zsh-syntax-highlighting): options and use ? instead of config and hasAttr

### DIFF
--- a/modules/home-manager/zsh-syntax-highlighting.nix
+++ b/modules/home-manager/zsh-syntax-highlighting.nix
@@ -1,5 +1,10 @@
 { catppuccinLib }:
-{ config, lib, ... }:
+{
+  options,
+  config,
+  lib,
+  ...
+}:
 
 let
   inherit (config.catppuccin) sources;
@@ -65,7 +70,7 @@ in
     (lib.mkIf cfg.enable {
       programs.zsh =
         let
-          key = if builtins.hasAttr "initContent" config.programs.zsh then "initContent" else "initExtra";
+          key = if options.programs.zsh ? initContent then "initContent" else "initExtra";
         in
         {
           # NOTE: Backwards compatible mkOrder priority working with stable/unstable HM.


### PR DESCRIPTION
There is no advantage to using builtins.hasAttr over ? in this case. There is no dynamic expression providing the attr to check for.

Furthermore, it is better to check for that attr under options rather than config for these reasons:
* it's easier to avoid infinite recursion when actually mutating a config attribute that you're checking by using the option only, and not the config; not necessarily that this would be caused by this, but as a general reason for doing it when you can
* checking the config attribute causes evaluation of the relevant modules to find anything that sets the attribute, but you only care that it exists or is defined at all. It is more efficient to only check options since it only needs to check modules that have option definitions.

and so it's better form to do it this way.

`nix fmt` was run against this PR.