### PR TITLE
fix(foot): update port for v1.22.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -32,7 +32,25 @@ let
         directory = ./pkgs;
       };
     in
-    generated // collected;
+    generated
+    // collected
+    /*
+      TODO(@getchoo): Remove this with 25.05!!!
+
+      Pin foot to an older version in Nixpkgs < 25.11. See:
+      - https://github.com/catppuccin/nix/issues/636
+      - https://github.com/catppuccin/nix/pull/622
+    */
+    // lib.optionalAttrs (!(lib.versionAtLeast lib.version "25.11pre")) {
+      foot = generated.foot.overrideAttrs (oldAttrs: {
+        src = oldAttrs.src.override {
+          rev = "962ff1a5b6387bc5419e9788a773a080eea5f1e1";
+          hash = "sha256-eVH3BY2fZe0/OjqucM/IZthV8PMsM9XeIijOg8cNE1Y=";
+        };
+
+        lastModified = "2024-09-24";
+      });
+    };
 in
 
 {

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -70,9 +70,9 @@
     "rev": "6a85af2ff722ad0f9fbc8424ea0a5c454661dfed"
   },
   "foot": {
-    "hash": "sha256-eVH3BY2fZe0/OjqucM/IZthV8PMsM9XeIijOg8cNE1Y=",
-    "lastModified": "2024-09-24",
-    "rev": "962ff1a5b6387bc5419e9788a773a080eea5f1e1"
+    "hash": "sha256-bpGVDESE6Pr7kaFgfAWJ/5KC9mRPlv2ciYwRr6jcIKs=",
+    "lastModified": "2025-07-20",
+    "rev": "8d263e0e6b58a6b9ea507f71e4dbf6870aaf8507"
   },
   "fuzzel": {
     "hash": "sha256-XpItMGsYq4XvLT+7OJ9YRILfd/9RG1GMuO6J4hSGepg=",


### PR DESCRIPTION
Upstream [has been udpated](https://github.com/catppuccin/foot/pull/20), without this change every time a foot terminal is started an error is printed.

@getchoo I'm assuming that `catppuccin` targets `nixos-unstable`, this change will now show an error when starting version `1.22.3` (on `nixos-25.05`)