### PR TITLE
fix: useFetchCargoVendor is non-optional and enabled by default as of 25.05

### DIFF
--- a/pkgs/catwalk/package.nix
+++ b/pkgs/catwalk/package.nix
@@ -18,7 +18,6 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Yj9xTQJ0eu3Ymi2R9fgYwBJO0V+4bN4MOxXCJGQ8NjU=";
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-stO8ejSC4UeEeMZZLIJ8Wabn7A6ZrWQlU5cZDSm2AVc=";
 
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/whiskers/package.nix
+++ b/pkgs/whiskers/package.nix
@@ -15,7 +15,6 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-OLEXy9MCrPQu1KWICsYhe/ayVqxkYIFwyJoJhgiNDz4=";
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-CVg7kcOTRa8KfDwiJHQhTPQfK6g3jOMa4h/BCUo3ehw=";
 
   passthru = {


### PR DESCRIPTION
This pull request makes a small change by removing the `useFetchCargoVendor` attribute from two `rustPlatform.buildRustPackage` definitions.

It was raising a warning like this one:

```
evaluation warning: buildRustPackage: `useFetchCargoVendor` is non‐optional and enabled by default as of 25.05, remove it
```

So here this fix follows the given instruction.

### Package definition updates:
* Removed the `useFetchCargoVendor` attribute from the `rustPlatform.buildRustPackage` definition in `pkgs/catwalk/package.nix`.
* Removed the `useFetchCargoVendor` attribute from the `rustPlatform.buildRustPackage` definition in `pkgs/whiskers/package.nix`.