### PR TITLE
fix(tests): update firefox module test options for #609

### DIFF
--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -1,5 +1,10 @@
 { lib, pkgs, ... }:
-
+let
+  firefoxModuleConfig = {
+    enable = true;
+    profiles.test.extensions.force = true;
+  };
+in
 {
   imports = [
     ../home-manager
@@ -20,14 +25,7 @@
     type = "fcitx5";
   };
 
-  catppuccin = {
-    # keep-sorted start
-    firefox.profiles.test = { };
-    floorp.profiles.test = { };
-    librewolf.profiles.test = { };
-    xfce4-terminal.enable = true;
-    # keep-sorted end
-  };
+  catppuccin.xfce4-terminal.enable = true;
 
   programs = {
     # keep-sorted start block=yes sticky_comments=yes
@@ -40,7 +38,9 @@
     cava.enable = true;
     chromium.enable = true;
     element-desktop.enable = true;
+    firefox = firefoxModuleConfig;
     fish.enable = true;
+    floorp = firefoxModuleConfig;
     foot.enable = true;
     freetube.enable = true;
     fuzzel.enable = true;
@@ -61,6 +61,7 @@
     k9s.enable = true;
     kitty.enable = true;
     lazygit.enable = true;
+    librewolf = firefoxModuleConfig;
     lsd.enable = true;
     mangohud.enable = true;
     micro.enable = true;


### PR DESCRIPTION
Since #609 the test options no longer work for testing the Firefox module, hence the missed build failure in https://github.com/catppuccin/nix/pull/627

~~This PR should result in a build failure currently, since the Firefox module is broken by 8b9f0bc231c854c78eb719921ca6831ed28003b9~~ fixed in https://github.com/catppuccin/nix/commit/2f0b779c531ac922a3f0e3f817ff4e794865873a