### PR TITLE
fix(home-manager/firefox): only apply to profiles specified

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -33,6 +33,10 @@ jobs:
         run: |
           nix fmt
 
+      - name: Install Node modules
+        run: |
+          nix develop --command pnpm install
+
       - name: Format with Prettier
         run: |
           nix develop --command nrr fmt

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -59,7 +59,8 @@
           in
 
           (pkgs.nixosOptionsDoc {
-            options = lib.removeAttrs eval.options [ "_module" ];
+            # You can also use this for backwards compat with < v1.2: `options = lib.removeAttrs eval.options [ "_module" ];`
+            options = { inherit (eval.options) catppuccin; };
 
             transformOptions =
               opt: lib.recursiveUpdate opt { declarations = replaceDeclarations opt.declarations; };

--- a/modules/home-manager/firefox.nix
+++ b/modules/home-manager/firefox.nix
@@ -101,11 +101,6 @@ let
                 }
               )
             );
-            # HACK(@getchoo): We need to to re-define these for doc generation :/
-            # The option we're merging with doesn't actually exist when only this homeModule is evaluated,
-            # so these values would be missing otherwise. That sucks
-            default = { };
-            description = "Catppuccin settings for ${prettyName} profiles.";
           };
         });
     };


### PR DESCRIPTION
~~Generally, using conditional option merging to apply these settings at
the submodule level:~~

~~- Breaks standalone evaluation of the homeModule (like in our docs)~~
~~- Allows for strange effects that only happen conditionally, like https://github.com/catppuccin/nix/pull/627#issuecomment-3134735931~~
  
The above is still a point I'd like to make, but conditional option merging is required here. We just need to be careful with it

Fixes #631, as well as a regression from #627