### PR TITLE
chore(modules)!: drop support for nixpkgs 24.11

### DIFF
--- a/modules/home-manager/swaync.nix
+++ b/modules/home-manager/swaync.nix
@@ -41,13 +41,7 @@ in
 
     # Install the default font if it is selected
     home.packages = lib.mkIf (cfg.font == "Ubuntu Nerd Font") [
-      # TODO: Remove when 25.05 is stable and `nerdfonts` is fully deprecated
-      (
-        if pkgs ? "nerd-fonts" then
-          pkgs.nerd-fonts.ubuntu
-        else
-          pkgs.nerdfonts.override { fonts = [ "Ubuntu" ]; }
-      )
+      pkgs.nerd-fonts.ubuntu
     ];
   };
 }

--- a/modules/home-manager/thunderbird.nix
+++ b/modules/home-manager/thunderbird.nix
@@ -16,7 +16,6 @@ in
     catppuccinLib.mkCatppuccinOption {
       name = "thunderbird";
       accentSupport = true;
-      default = lib.versionAtLeast config.home.stateVersion "25.05" && config.catppuccin.enable;
     }
     // {
       profile = lib.mkOption {
@@ -27,10 +26,6 @@ in
     };
 
   config = lib.mkIf enable {
-
-    # extensions support was added in https://github.com/nix-community/home-manager/pull/6033
-    assertions = [ (catppuccinLib.assertMinimumVersion "25.05") ];
-
     programs.thunderbird = {
       profiles."${cfg.profile}".extensions = [
         (pkgs.runCommandLocal "catppuccin-${cfg.flavor}-${cfg.accent}.thunderbird.theme"


### PR DESCRIPTION
Considering 24.11 has been EOL for a while at this point, this is probably fine
