### PR TITLE
chore(devshell): pin nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,20 +57,18 @@
 
       devShells = forAllDevSystems (
         system:
+
         let
           pkgs = nixpkgs.legacyPackages.${system};
         in
-        {
-          default = import ./shell.nix { inherit pkgs; };
 
-          ci = pkgs.mkShellNoCC {
-            packages = with pkgs; [
-              nodejs-slim_22
-              corepack
-              nrr
-            ];
-          };
-        }
+        lib.genAttrs [ "default" "ci" ] (
+          name:
+          import ./shell.nix {
+            inherit pkgs;
+            minimal = name == "ci";
+          }
+        )
       );
 
       formatter = forAllDevSystems (

--- a/shell.nix
+++ b/shell.nix
@@ -5,35 +5,52 @@
     overlays = [ ];
   },
   system ? builtins.currentSystem,
+  minimal ? false,
 }:
 
 pkgs.mkShellNoCC {
-  packages = with pkgs; [
-    # Nix tools
-    deadnix
-    nixfmt-rfc-style
-    nil
-    statix
+  packages =
+    with pkgs;
+    [
+      /*
+        WARN(@getchoo): KEEP A SAFE NIX PINNED!!
 
-    # GHA lints
-    actionlint
+        We end up relying on some features exclusive to Nix, like relative path inputs
+        https://git.lix.systems/lix-project/lix/issues/641
 
-    # Python tools for paws.py
-    pyright
-    ruff
+        We also run into inconsistent evaluation with "distributions" of Nix
+        and their features - like DetNix and Lazy Trees
 
-    # Node tooling for Astro/Starlight
-    nodejs-slim_22
-    corepack
+        Basically: Nix is the only one that evaluates our development Flake correctly. Yay.
+      */
+      nixVersions.nix_2_28
 
-    nrr
+      # Node tooling for Astro/Starlight
+      nodejs-slim_22
+      corepack
+      nrr
+    ]
+    ++ lib.optionals (!minimal) [
+      # Nix tools
+      deadnix
+      nixfmt-rfc-style
+      nil
+      statix
 
-    astro-language-server
-    typescript-language-server
+      # GHA lints
+      actionlint
 
-    # Shell lints
-    shellcheck
-  ];
+      # Python tools for paws.py
+      pyright
+      ruff
+
+      # More node tooling for Astro/Starlight
+      astro-language-server
+      typescript-language-server
+
+      # Shell lints
+      shellcheck
+    ];
 
   shellHook = ''
     echo "Welcome to the catppuccin/nix repository! Thanks for contributing and have a wonderful day 🐈"


### PR DESCRIPTION
https://wetdry.world/@getchoo/114962325064525100

We could also just...stop using a development Flake again, eat a home-manager input in the root Flake, and move all the outputs to there? This would only fix compatibility with Lix, though

Maybe something with traditional Nix, grabbing Nixpkgs from our root flake.lock, and pinning home-manager elsewhere? This would fix both, but sounds painful.

I don't know. This works for now.
