### PR TITLE
ci(website): add concurrency rule to deploy

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -77,6 +77,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: github-pages
+      cancel-in-progress: true
+
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}


### PR DESCRIPTION
Helps prevent multiple deploys from running at the same time and both
failing
