### PR TITLE
fix(home-manager/freetube): fix theme setting formatting

### DIFF
--- a/modules/home-manager/freetube.nix
+++ b/modules/home-manager/freetube.nix
@@ -3,8 +3,6 @@
 
 let
   inherit (lib) toSentenceCase;
-  inherit (config.programs.freetube.settings) baseTheme;
-
   cfg = config.catppuccin.freetube;
 in
 
@@ -55,8 +53,8 @@ in
     programs.freetube.settings = {
       # NOTE: For some reason, baseTheme does not capitalize first letter, but the other settings do
       baseTheme = "catppuccin${toSentenceCase cfg.flavor}";
-      mainColor = toSentenceCase "${baseTheme}${toSentenceCase cfg.accent}";
-      secColor = toSentenceCase "${baseTheme}${toSentenceCase cfg.secondaryAccent}";
+      mainColor = "Catppuccin${toSentenceCase cfg.flavor}${toSentenceCase cfg.accent}";
+      secColor = "Catppuccin${toSentenceCase cfg.flavor}${toSentenceCase cfg.secondaryAccent}";
     };
   };
 }


### PR DESCRIPTION
The behavior of `lib.toSentenceCase` seems to have changed, which broke how the settings for `mainColor` and `secColor` were formatted. (e.g. What should have been CatppuccinMochaMauve became Catppuccinmochamauve)

This slightly changes how FreeTube support is implemented to account for this.