### PR TITLE
 feat(yazi): move theme files to "flavors"

### DIFF
--- a/modules/home-manager/yazi.nix
+++ b/modules/home-manager/yazi.nix
@@ -25,11 +25,18 @@ in
   };
 
   config = lib.mkIf enable {
+    programs.yazi.theme = {
+      flavor = {
+        light = "catppuccin";
+        dark = "catppuccin";
+      };
+    };
+
     xdg.configFile = {
-      "yazi/theme.toml".source =
+      "yazi/flavors/catppuccin.yazi/flavor.toml".source =
         "${sources.yazi}/${cfg.flavor}/catppuccin-${cfg.flavor}-${cfg.accent}.toml";
 
-      "yazi/Catppuccin-${cfg.flavor}.tmTheme".source =
+      "yazi/flavors/catppuccin.yazi/tmTheme.tmTheme".source =
         "${sources.bat}/Catppuccin ${lib.toSentenceCase cfg.flavor}.tmTheme";
     };
   };


### PR DESCRIPTION
Moving theme files to the ./flavors subfolder, this allow the user to override some values via home-manager provided 'theme' option.

Documentation : https://yazi-rs.github.io/docs/flavors/overview