### PR TITLE
docs: Update obsolete flake attribute for importing catppuccin

### DIFF
--- a/docs/content/docs/Getting Started/flakes.mdx
+++ b/docs/content/docs/Getting Started/flakes.mdx
@@ -107,7 +107,7 @@ By the end, you should have a flake.nix that looks something like this
           home-manager.users.pepperjack = {
             imports = [
               ./home.nix
-              catppuccin.homeManagerModules.catppuccin
+              catppuccin.homeModules.catppuccin
             ];
           };
         }
@@ -119,7 +119,7 @@ By the end, you should have a flake.nix that looks something like this
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
       modules = [
         ./home.nix
-        catppuccin.homeManagerModules.catppuccin
+        catppuccin.homeModules.catppuccin
       ];
     };
   };


### PR DESCRIPTION
`trace: evaluation warning: Obsolete Flake attribute 'catppuccin.homeManagerModules.catppuccin' is used. It was renamed to 'catppuccin.homeModules.catppuccin'.`

The first two examples on the page have it correct, but in the "end flake", it's using the old attribute.