### PR TITLE
feat(wezterm): set flavor and accent as plugin options

### DIFF
--- a/modules/home-manager/wezterm.nix
+++ b/modules/home-manager/wezterm.nix
@@ -16,8 +16,6 @@ in
 
   config = lib.mkIf cfg.enable {
     programs.wezterm = {
-      colorSchemes."catppuccin-${cfg.flavor}" =
-        lib.importTOML "${sources.wezterm}/dist/catppuccin-${cfg.flavor}.toml";
       extraConfig = lib.mkBefore (
         ''
           local catppuccin_plugin = "${sources.wezterm}/plugin/init.lua"

--- a/modules/home-manager/wezterm.nix
+++ b/modules/home-manager/wezterm.nix
@@ -1,24 +1,32 @@
 { catppuccinLib }:
 { config, lib, ... }:
-
 let
   inherit (config.catppuccin) sources;
   cfg = config.catppuccin.wezterm;
 in
 {
-  options.catppuccin.wezterm = catppuccinLib.mkCatppuccinOption { name = "wezterm"; } // {
-    apply = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Apply Catppuccin theme to WezTerm.";
+  options.catppuccin.wezterm =
+    catppuccinLib.mkCatppuccinOption {
+      name = "wezterm";
+      accentSupport = true;
+    }
+    // {
+      apply = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Apply Catppuccin theme to WezTerm.";
+      };
     };
-  };
 
   config = lib.mkIf cfg.enable {
     programs.wezterm = {
       extraConfig = lib.mkBefore (
         ''
           local catppuccin_plugin = "${sources.wezterm}/plugin/init.lua"
+          local catppuccin_config = {
+            flavor = "${cfg.flavor}",
+            accent = "${cfg.accent}",
+          }
         ''
         + lib.optionalString cfg.apply ''
           local config = {}
@@ -26,7 +34,7 @@ in
             config = wezterm.config_builder()
           end
 
-          dofile("${sources.wezterm}/plugin/init.lua").apply_to_config(config)
+          dofile("${sources.wezterm}/plugin/init.lua").apply_to_config(config, catppuccin_config)
         ''
       );
     };


### PR DESCRIPTION
Use catppuccin config to set options in the catppuccin WezTerm plugin. This also enables support for accent. The plugin's `sync` option could also be used for future support for light and dark flavors.

---
We no longer set `colorSchemes` for WezTerm but I don't think it ever worked as intended. The colorSchemes option from home-manager [puts values in the set `colors`](https://github.com/nix-community/home-manager/blob/6159629d05a0e92bb7fb7211e74106ae1d552401/modules/programs/wezterm.nix#L113-L118) which results in the output file having tables like `[colors.colors]` ([output file with default options](https://gist.github.com/signegrau/af52d601053d9683be2a26f62913265b#file-catppuccin-mocha-toml)). WezTerm does not like this as seen in the debug overlay
```
23:21:52.030 WARN wezterm_dynamic::error > `colors` is not a valid Palette field.  There are too many alternatives to list here; consult the documentation!
23:21:52.030 WARN wezterm_dynamic::error > `metadata` is not a valid Palette field.  There are too many alternatives to list here; consult the documentation!
23:21:52.030 ERROR config::config > Color scheme in `/Users/signe/.config/wezterm/colors/catppuccin-mocha.toml` failed to load: parsing TOML: scheme is missing ANSI colors
```
However [WezTerm already includes catppuccin themes](https://wezterm.org/colorschemes/c/index.html#catppuccin-mocha) from the [official WezTerm port](https://github.com/catppuccin/wezterm) so `catppuccin-mocha` and the other flavors are already defined, which is why the themes seem to work. The catppuccin plugin also uses the [same names used by Wezterm](https://github.com/catppuccin/wezterm/blob/b1a81bae74d66eaae16457f2d8f151b5bd4fe5da/plugin/init.lua#L120-L125) for the official schemes