### PR TITLE
feat(home-manager): add support for vivid

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -57,6 +57,7 @@
   ./tmux.nix
   ./tofi.nix
   ./vesktop.nix
+  ./vivid.nix
   ./vscode.nix
   ./waybar.nix
   ./wezterm.nix

--- a/modules/home-manager/vivid.nix
+++ b/modules/home-manager/vivid.nix
@@ -1,0 +1,12 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+let
+  cfg = config.catppuccin.vivid;
+in
+{
+  options.catppuccin.vivid = catppuccinLib.mkCatppuccinOption { name = "vivid"; };
+
+  config = lib.mkIf cfg.enable {
+    programs.vivid.activeTheme = "catppuccin-${cfg.flavor}";
+  };
+}

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -78,6 +78,7 @@ in
     tmux.enable = true;
     tofi.enable = isLinux;
     vesktop.enable = true;
+    vivid.enable = true;
     vscode = {
       enable = true;
       package = pkgs.vscodium;


### PR DESCRIPTION
Adds support for vivid. It already comes with catppuccin themes, so no new sources have been added.

Closes #715