### PR TITLE
feat(nixos): add support for cursors and icons

### DIFF
--- a/modules/nixos/all-modules.nix
+++ b/modules/nixos/all-modules.nix
@@ -1,8 +1,10 @@
 [
   # keep-sorted start
+  ./cursors.nix
   ./fcitx5.nix
   ./gitea.nix
   ./grub.nix
+  ./gtk.nix
   ./limine.nix
   ./plymouth.nix
   ./sddm.nix

--- a/modules/nixos/cursors.nix
+++ b/modules/nixos/cursors.nix
@@ -1,0 +1,58 @@
+{ catppuccinLib }:
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  inherit (config.catppuccin) sources;
+
+  cfg = config.catppuccin.cursors;
+
+  # "dark" and "light" can be used alongside the regular accents
+  cursorAccentType = lib.types.mergeTypes catppuccinLib.types.accent (
+    lib.types.enum [
+      "dark"
+      "light"
+    ]
+  );
+in
+
+{
+  options.catppuccin.cursors =
+    (catppuccinLib.mkCatppuccinOption {
+      name = "pointer cursors";
+      # NOTE: We exclude this as there is no `enable` option in the upstream
+      # module to guard it
+      useGlobalEnable = false;
+    })
+    // {
+      accent = lib.mkOption {
+        type = cursorAccentType;
+        default = config.catppuccin.accent;
+        description = "Catppuccin accent for pointer cursors";
+      };
+    };
+
+  config =
+    lib.mkIf
+      (
+        cfg.enable
+        && (config.services.desktopManager.gnome.enable || config.services.displayManager.gdm.enable)
+      )
+      {
+        environment.systemPackages = [
+          sources.cursors
+        ];
+
+        programs.dconf.profiles.gdm.databases = [
+          {
+            lockAll = true;
+            settings."org/gnome/desktop/interface" = {
+              cursor-theme = "catppuccin-${cfg.flavor}-${cfg.accent}-cursors";
+            };
+          }
+        ];
+      };
+}

--- a/modules/nixos/gtk.nix
+++ b/modules/nixos/gtk.nix
@@ -1,0 +1,49 @@
+{ catppuccinLib }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.catppuccin.gtk;
+in
+{
+  options.catppuccin.gtk = {
+    icon = catppuccinLib.mkCatppuccinOption {
+      name = "GTK modified Papirus icon theme";
+
+      accentSupport = true;
+    };
+  };
+
+  config =
+    lib.mkIf
+      (
+        cfg.icon.enable
+        && (config.services.desktopManager.gnome.enable || config.services.displayManager.gdm.enable)
+      )
+      {
+        services.displayManager.environment.XDG_DATA_DIRS = (
+          (lib.makeSearchPath "share" [
+            (pkgs.catppuccin-papirus-folders.override { inherit (cfg.icon) accent flavor; })
+          ])
+          + ":"
+        );
+
+        programs.dconf.profiles.gdm.databases = [
+          {
+            lockAll = true;
+            settings."org/gnome/desktop/interface" =
+              let
+                # use the light icon theme for latte
+                polarity = if cfg.icon.flavor == "latte" then "Light" else "Dark";
+              in
+              {
+                icon-theme = "Papirus-${polarity}";
+              };
+          }
+        ];
+      };
+}


### PR DESCRIPTION
Adds support for cursors and icons settings in the NixOS modules.

The general use-case here is for applying the cursor and icons settings to the login manager. I've only added support for GNOME because that's what I use, but support for other login managers could be added in the future.