### PR TITLE
fix: use `extra-*` for cache settings

### DIFF
--- a/modules/global.nix
+++ b/modules/global.nix
@@ -51,8 +51,10 @@ in
 
   config = {
     nix.settings = lib.mkIf config.catppuccin.cache.enable {
-      substituters = [ "https://catppuccin.cachix.org" ];
-      trusted-public-keys = [ "catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU=" ];
+      extra-substituters = [ "https://catppuccin.cachix.org" ];
+      extra-trusted-public-keys = [
+        "catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU="
+      ];
     };
   };
 }


### PR DESCRIPTION
Replace `substituters` and `trusted-public-keys` with `extra-subtituters` and `extra-trusted-public-keys` for cache settings.

Setting `substituter` will cause the default substituter `https://cache.nixos.org` to be replaced, which will force the user to locally build the entire universe. This isn't a problem for NixOS because they have a safeguard in place:

[`nixos/modules/config/nix.nix`](https://github.com/NixOS/nixpkgs/blob/0445c79f38b413221521cc0f89735f0b0d823b5b/nixos/modules/config/nix.nix#L373)

```nix
config = mkIf cfg.enable {
  ...
  nix.settings = {
    ...
    substituters = mkAfter [ "https://cache.nixos.org/" ];
    ...
  };
};
```

But home-manager has none, and this footgun bit me real hard.