### PR TITLE
fix(home-manager/kvantum): remove platform theme assertion

### DIFF
--- a/modules/home-manager/kvantum.nix
+++ b/modules/home-manager/kvantum.nix
@@ -64,10 +64,6 @@ in
         ];
         message = ''`qt.style.name` must be `"kvantum"` to use `qt.style.catppuccin`'';
       }
-      {
-        assertion = lib.elem (config.qt.platformTheme.name or null) [ "kvantum" ];
-        message = ''`qt.platformTheme.name` must be set to `"kvantum"` to use `qt.style.catppuccin`'';
-      }
     ];
 
     xdg.configFile = {


### PR DESCRIPTION
As discussed here, setting `QT_QPA_PLATFORMTHEME` may be unnecessary: https://github.com/catppuccin/nix/issues/430#issuecomment-3346642996

But more importantly, the option enforced by the assertion simply does not work for certain platforms. This will leave the user's system in a broken state while at the same time preventing that very user from fixing it. It's *very* frustrating situation to be in.

For now, I propose simply removing the assertion until we have more data on what works and what doesn't.

On the other hand, I chose to leave the `QT_STYLE_OVERRIDE` assertion untouched because I believe it should be correct based on my experience and various online discussions I've come across.

If anyone have experience with setting Kvantum across different platforms (e.g. GNOME, KDE, plain `wlroots` compositors, etc.), I'd appreciate your feedback here. 