### PR TITLE
feat(home-manager/qutebrowser): add plainLook option

### DIFF
--- a/modules/home-manager/qutebrowser.nix
+++ b/modules/home-manager/qutebrowser.nix
@@ -17,13 +17,15 @@ let
 in
 
 {
-  options.catppuccin.qutebrowser = catppuccinLib.mkCatppuccinOption { name = "qutebrowser"; };
+  options.catppuccin.qutebrowser = catppuccinLib.mkCatppuccinOption { name = "qutebrowser"; } // {
+    plainLook = lib.mkEnableOption "plain look for the menu rows";
+  };
 
   config = lib.mkIf enable {
     programs.qutebrowser = {
       extraConfig = lib.mkMerge [
         (lib.mkBefore "import catppuccin")
-        (lib.mkAfter "catppuccin.setup(c, '${cfg.flavor}', True)")
+        (lib.mkAfter "catppuccin.setup(c, '${cfg.flavor}', ${lib.toSentenceCase (lib.boolToString cfg.plainLook)})")
       ];
     };
 


### PR DESCRIPTION
Resolves #745

Added a plainLook option. The default is set to false like upstream.

It could be possible, that I need to invert the bool, please let me know which one is correct.
```diff
- (lib.mkAfter "catppuccin.setup(c, '${cfg.flavor}', ${boolToString cfg.plainLook})")
+ (lib.mkAfter "catppuccin.setup(c, '${cfg.flavor}', ${boolToString !cfg.plainLook})")
```