### PR TITLE
feat(home-manager/cursors): add options to build specific cursor themes

### DIFF
--- a/pkgs/cursors/package.nix
+++ b/pkgs/cursors/package.nix
@@ -9,6 +9,8 @@
   xcur2png,
   xorg,
   zip,
+  flavors ? [ ],
+  accents ? [ ],
 }:
 
 buildCatppuccinPort (finalAttrs: {
@@ -27,13 +29,26 @@ buildCatppuccinPort (finalAttrs: {
     zip
   ];
 
-  buildPhase = ''
-    runHook preBuild
+  buildPhase =
+    let
+      numFlavors = lib.length flavors;
+      numAccents = lib.length accents;
+      accentString' = lib.concatStringsSep " " accents;
+      accentString = if numAccents == 0 then "" else "'${accentString'}'";
+      buildFlavor = flavor: "just build ${flavor} ${accentString}";
+      buildCmd =
+        if numFlavors == 0 then
+          "just all"
+        else
+          lib.concatStringsSep "\n" (builtins.map buildFlavor flavors);
+    in
+    ''
+      runHook preBuild
 
-    just all
+      ${buildCmd}
 
-    runHook postBuild
-  '';
+      runHook postBuild
+    '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
These option allow for manually selecting which flavors and accents to build, decreasing build times for users.

I made it so the lists of flavors and accents is empty, and the code in the `buildPhase` then checks if they are empty and simply outputs the default `just all`, if that is the case.

The code can be quite smaller if the lists are filled out by default, although this makes the beginning of the file quite a bit longer, as the formatter puts each element on a new line.

It would be nice to have the `flavors` and `accents` parameters set by default via `catppuccin.cursors`, as the build times are quite long. But I am unsure if this would break things, so I haven't done that yet.