### PR TITLE
fix(pkgs/buildcatppuccinport): failing meta checks

### DIFF
--- a/pkgs/buildCatppuccinPort/package.nix
+++ b/pkgs/buildCatppuccinPort/package.nix
@@ -35,7 +35,7 @@ lib.extendMkDerivation {
           getchoo
           isabelroses
         ];
-        platform = lib.platforms.all;
+        platforms = lib.platforms.all;
       }
       // args.meta or { };
     };


### PR DESCRIPTION
Configs using [`checkMeta`](https://nixos.org/manual/nixpkgs/unstable/#opt-checkMeta) fail because of this typo.