### PR TITLE
feat(home-manager): add support for anki

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -2,6 +2,7 @@
   # keep-sorted start
   ./aerc.nix
   ./alacritty.nix
+  ./anki.nix
   ./atuin.nix
   ./bat.nix
   ./bottom.nix

--- a/modules/home-manager/anki.nix
+++ b/modules/home-manager/anki.nix
@@ -1,0 +1,37 @@
+{ catppuccinLib }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.catppuccin.anki;
+in
+
+{
+  options.catppuccin.anki = catppuccinLib.mkCatppuccinOption { name = "anki"; };
+
+  config = lib.mkIf cfg.enable {
+    programs.anki = {
+      addons = with pkgs.ankiAddons; [
+        (recolor.withConfig {
+          config =
+            let
+              polarity = if config.catppuccin.flavor == "latte" then "light" else "dark";
+              flavor = lib.toSentenceCase config.catppuccin.flavor;
+              version = builtins.splitVersion recolor.version;
+            in
+            (lib.importJSON "${recolor}/share/anki/addons/recolor/themes/(${polarity}) Catppuccin ${flavor}.json")
+            // {
+              version = {
+                major = lib.toInt (builtins.elemAt version 0);
+                minor = lib.toInt (builtins.elemAt version 1);
+              };
+            };
+        })
+      ];
+    };
+  };
+}

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -25,6 +25,7 @@ in
     # keep-sorted start block=yes sticky_comments=yes
     aerc.enable = true;
     alacritty.enable = true;
+    anki.enable = true;
     bat.enable = true;
     bottom.enable = true;
     brave.enable = true;


### PR DESCRIPTION
This unfortunately requires IFD, for now. I'm working on a fix upstream: https://github.com/catppuccin/nix/issues/706, but it hasn't been gathering much feedback. The IFD can be removed when/if it gets merged.

The version number manipulation is necessary because of the following issues:

- https://github.com/NixOS/nixpkgs/issues/447179
- https://github.com/AnKing-VIP/AnkiRecolor/pull/48

But again, not much progress. 

I've been daily driving this for a few months now and it works great.

Fix: https://github.com/catppuccin/nix/issues/706