### PR TITLE
fcitx5: set home-manager theme via addons

### DIFF
--- a/modules/home-manager/fcitx5.nix
+++ b/modules/home-manager/fcitx5.nix
@@ -15,10 +15,6 @@ let
       )
       || config.i18n.inputMethod.enabled == "fcitx5"
     );
-
-  package = sources.fcitx5.override {
-    inherit (cfg) enableRounded;
-  };
 in
 
 {
@@ -69,19 +65,11 @@ in
     ];
 
   config = lib.mkIf enable {
-    xdg.dataFile = {
-      "fcitx5/themes/catppuccin-${cfg.flavor}-${cfg.accent}" = {
-        source = "${package}/share/fcitx5/themes/catppuccin-${cfg.flavor}-${cfg.accent}";
-        recursive = true;
-      };
-    };
-
-    xdg.configFile = {
-      "fcitx5/conf/classicui.conf" = lib.mkIf cfg.apply {
-        text = lib.generators.toINIWithGlobalSection { } {
-          globalSection.Theme = "catppuccin-${cfg.flavor}-${cfg.accent}";
-        };
-      };
+    i18n.inputMethod.fcitx5 = {
+      addons = [
+        (sources.fcitx5.override { inherit (cfg) enableRounded; })
+      ];
+      settings.addons.classicui.globalSection.Theme = "catppuccin-${cfg.flavor}-${cfg.accent}";
     };
   };
 }


### PR DESCRIPTION
Fixes #696. Credit to @sollniss, who found the same workaround I initially did but went one step further in pointing out the NixOS version.

Previously, setting any custom `i18n.inputMethod.fcitx5.settings` would cause home-manager to take control of the `~/.config/fcitx5` directory (AKA: `xdg.configFile.fcitx5`). 

```
╰─ ls -la ~/.config
...snip
lrwxrwxrwx   - nickthegroot  3 Jan 22:31 fcitx5 -> /nix/store/31q4f8nzwv37ynlrcsm61j7nra9j9b9w-home-manager-files/.config/fcitx5
```

This meant that the config file would attempt to be generated into `/nix/store`, which home-manager correctly refuses to do (outside $HOME).

This PR fixes the issue by configuring classicui through the home-manager `settings.addons.classicui.globalSection` attribute, the same way that's currently being used for the NixOS module.

