### PR TITLE
feat(home-manager/wleave): init

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -65,6 +65,7 @@
   ./vscode.nix
   ./waybar.nix
   ./wezterm.nix
+  ./wleave.nix
   ./wlogout.nix
   ./xfce4-terminal.nix
   ./yazi.nix

--- a/modules/home-manager/wleave.nix
+++ b/modules/home-manager/wleave.nix
@@ -1,0 +1,66 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+
+let
+  inherit (config.catppuccin) sources;
+
+  cfg = config.catppuccin.wleave;
+in
+
+{
+  options.catppuccin.wleave =
+    catppuccinLib.mkCatppuccinOption {
+      name = "wleave";
+      accentSupport = true;
+    }
+    // {
+      iconStyle = lib.mkOption {
+        type = lib.types.enum [
+          "wlogout"
+          "wleave"
+        ];
+        description = "Icon style to set in ~/.config/wleave/style.css";
+        default = "wleave";
+        example = lib.literalExpression "wleave";
+      };
+
+      extraStyle = lib.mkOption {
+        type = lib.types.lines;
+        description = "Additional CSS to put in ~/.config/wleave/style.css";
+        default = "";
+        example = lib.literalExpression ''
+          button {
+            border-radius: 2px;
+          }
+
+          #lock {
+            background-image: url("''${config.gtk.iconTheme.package}/share/icons/''${config.gtk.iconTheme.name}/apps/scalable/system-lock-screen.svg");
+          }
+        '';
+      };
+    };
+
+  config = lib.mkIf cfg.enable {
+    programs.wleave.style = lib.concatStrings [
+      ''
+        @import url("${sources.wlogout}/themes/${cfg.flavor}/${cfg.accent}.css");
+      ''
+      (lib.concatMapStrings
+        (icon: ''
+          #${icon} {
+            background-image: url("${sources.wlogout}/icons/${cfg.iconStyle}/${cfg.flavor}/${cfg.accent}/${icon}.svg");
+          }
+        '')
+        [
+          "hibernate"
+          "lock"
+          "logout"
+          "reboot"
+          "shutdown"
+          "suspend"
+        ]
+      )
+      cfg.extraStyle
+    ];
+  };
+}

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -93,6 +93,7 @@ in
     };
     waybar.enable = isLinux;
     wezterm.enable = true;
+    wleave.enable = isLinux;
     wlogout.enable = isLinux;
     yazi.enable = true;
     zathura.enable = true;


### PR DESCRIPTION
a exact clone of wlogout but defaulting to the wleave icons. this should be fine for now since wleave supports the old wlogout configurations style but this may change so its a good idea to have a seprate module. catppuccin/wlogout also supports wlogout making this somewhat easy. closes https://github.com/catppuccin/nix/issues/740