### PR TITLE
feat(home-manager/kvantum): add style assertion option

### DIFF
--- a/modules/home-manager/kvantum.nix
+++ b/modules/home-manager/kvantum.nix
@@ -27,10 +27,19 @@ in
           If this is disabled, you must manually set the theme (e.g. by using `kvantummanager`).
         '';
       };
+
+      assertStyle = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        example = false;
+        description = ''
+          Wether to assert that {option}`qt.style.name` is set to `"kvantum"` when Kvantum themes are enabled.
+        '';
+      };
     };
 
   config = lib.mkIf enable {
-    assertions = [
+    assertions = lib.mkIf cfg.assertStyle [
       {
         assertion = lib.elem config.qt.style.name [
           "kvantum"


### PR DESCRIPTION
this option is ment for users that want install the theme but don't want to use another style like qt5ct

closes https://github.com/catppuccin/nix/issues/786