### PR TITLE
Respect catppuccin.fcitx5.apply

### DIFF
--- a/modules/home-manager/fcitx5.nix
+++ b/modules/home-manager/fcitx5.nix
@@ -41,7 +41,9 @@ in
       addons = [
         (sources.fcitx5.override { inherit (cfg) enableRounded; })
       ];
-      settings.addons.classicui.globalSection.Theme = "catppuccin-${cfg.flavor}-${cfg.accent}";
+      settings.addons = lib.mkIf cfg.apply {
+        classicui.globalSection.Theme = "catppuccin-${cfg.flavor}-${cfg.accent}";
+      };
     };
   };
 }


### PR DESCRIPTION
Simple fix to a bug introduced in #797, where the fcitx5 module no longer respects the catppuccin.fcitx5.apply setting