### PR TITLE
feat(home-manager): add support for gemini-cli

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -21,6 +21,7 @@
   ./freetube.nix
   ./fuzzel.nix
   ./fzf.nix
+  ./gemini-cli.nix
   ./gh-dash.nix
   ./ghostty.nix
   ./gitui.nix

--- a/modules/home-manager/gemini-cli.nix
+++ b/modules/home-manager/gemini-cli.nix
@@ -1,0 +1,22 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+
+let
+  inherit (config.catppuccin) sources;
+
+  cfg = config.catppuccin.gemini-cli;
+  theme = lib.importJSON "${sources.gemini-cli}/catppuccin-${cfg.flavor}.json";
+in
+
+{
+  options.catppuccin.gemini-cli = catppuccinLib.mkCatppuccinOption { name = "gemini-cli"; };
+
+  config = lib.mkIf cfg.enable {
+    programs.gemini-cli = {
+      settings.ui = {
+        theme = theme.name;
+        customThemes.${theme.name} = theme;
+      };
+    };
+  };
+}

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -59,6 +59,7 @@ in
     freetube.enable = isLinux;
     fuzzel.enable = isLinux;
     fzf.enable = true;
+    gemini-cli.enable = true;
     gh-dash.enable = true;
     ghostty.enable = isLinux;
     git.enable = true;

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -84,6 +84,11 @@
     "lastModified": "2024-10-30",
     "rev": "0af0e26901b60ada4b20522df739f032797b07c3"
   },
+  "gemini-cli": {
+    "hash": "sha256-ISUr8Gnknb+8nnlsGbP2aVXAxQtBPbiaTc7MqsecBk4=",
+    "lastModified": "2026-01-15",
+    "rev": "6b78ab52a0569cac80158c643e7699d0a116aebc"
+  },
   "gh-dash": {
     "hash": "sha256-fOCZxrEyWLi+VYnx3QYOP1R+VBhllhOlnO5/5Wg5aq4=",
     "lastModified": "2024-10-30",


### PR DESCRIPTION
~Blocked by: https://github.com/catppuccin/gemini-cli/pull/2~

This requires IFD as `gemini-cli` does not support loading themes from outside of home directory. ([Source](https://geminicli.com/docs/cli/themes/#loading-themes-from-a-file:~:text=Security%20note%3A,from%20untrusted%20sources.))