### PR TITLE
feat(home-manager): add support for broot

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -6,6 +6,7 @@
   ./atuin.nix
   ./bat.nix
   ./bottom.nix
+  ./broot.nix
   ./btop.nix
   ./cava.nix
   ./chrome.nix

--- a/modules/home-manager/broot.nix
+++ b/modules/home-manager/broot.nix
@@ -1,0 +1,44 @@
+{ catppuccinLib }:
+{
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (config.catppuccin) sources;
+
+  cfg = config.catppuccin.broot;
+  enable = cfg.enable && config.programs.broot.enable;
+
+  themeFile = "catppuccin-${cfg.flavor}-${cfg.accent}.hjson";
+in
+{
+  options.catppuccin.broot = catppuccinLib.mkCatppuccinOption {
+    name = "broot";
+    accentSupport = true;
+  };
+
+  config = lib.mkIf enable {
+    xdg.configFile = {
+      "broot/skins/${themeFile}".source = "${sources.broot}/${cfg.flavor}/${themeFile}";
+    };
+
+    programs.broot = {
+      settings = {
+        imports = [
+          {
+            file = "skins/${themeFile}";
+            luma = "light";
+          }
+          {
+            file = "skins/${themeFile}";
+            luma = [
+              "dark"
+              "unknown"
+            ];
+          }
+        ];
+      };
+    };
+  };
+}

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -40,6 +40,7 @@ in
     bottom.enable = true;
     brave.enable = true;
     btop.enable = true;
+    broot.enable = true;
     cava.enable = true;
     chromium.enable = isLinux;
     delta = {

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -24,6 +24,11 @@
     "lastModified": "2025-04-18",
     "rev": "eadd75acd0ecad4a58ade9a1d6daa3b97ccec07c"
   },
+  "broot": {
+    "hash": "sha256-A/DnTzN6D4s/O50Qf+TUxhT00LH0RJ1iA3T45XGzUrk=",
+    "lastModified": "2025-08-11",
+    "rev": "404357d2e5abbf8d28658796696995d4410e3390"
+  },
   "btop": {
     "hash": "sha256-mEGZwScVPWGu+Vbtddc/sJ+mNdD2kKienGZVUcTSl+c=",
     "lastModified": "2024-09-23",


### PR DESCRIPTION
Adds support for [broot](https://home-manager-options.extranix.com/?release=master&query=broot).

There is an option `programs.broot.settings.skin` that allows setting the values directly, but unfortionately [catppuccin/broot](https://github.com/catppuccin/broot) only has hjson files, which I don't think can be parsed with nix. According to the [docs](https://dystroy.org/broot/conf_file/), broot supports toml files as well, but it is what it is ...

default (left is unthemed shell, right is themed shell)
<img width="961" height="568" alt="default" src="https://github.com/user-attachments/assets/33d0d285-2205-41fb-a5cb-5d188730a226" />

latte-yellow (right shell is latte only with default accent, broot itself is latte-yellow)
<img width="945" height="582" alt="latte-yellow" src="https://github.com/user-attachments/assets/b43974b5-6724-46e4-a3ef-991a42475810" />
