### PR TITLE
Deprecation warning in GTK

### DIFF
--- a/modules/nixos/gtk.nix
+++ b/modules/nixos/gtk.nix
@@ -25,7 +25,7 @@ in
         && (config.services.desktopManager.gnome.enable || config.services.displayManager.gdm.enable)
       )
       {
-        services.displayManager.environment.XDG_DATA_DIRS = (
+        services.displayManager.generic.environment.XDG_DATA_DIRS = (
           (lib.makeSearchPath "share" [
             (pkgs.catppuccin-papirus-folders.override { inherit (cfg.icon) accent flavor; })
           ])


### PR DESCRIPTION
With [this](https://github.com/NixOS/nixpkgs/pull/480050) pull request in nixpkgs enabling the GTK theming gives the following warning

```shell
evaluation warning: The option `services.displayManager.environment'
defined in
`/nix/store/8gr4p4wzap658n1pfglpsi09fwqv40hq-source/modules/nixos/gtk.nix'
has been renamed to `services.displayManager.generic.environment'.
```

This PR should fix the warning and close #836 