### PR TITLE
fix(nixos): rename deprecated displayManager.environment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,19 +37,20 @@ in
 
 {
   # Filter out derivations not available on/meant for the current system
-  packages = lib.filterAttrs (lib.const (
-    deriv:
-    let
-      # Only export packages available on the current system, *unless* they are being cross compiled
-      availableOnHost = lib.meta.availableOn pkgs.stdenv.hostPlatform deriv;
-      # `nix flake check` doesn't like broken packages
-      broken = deriv.meta.broken or false;
-      isCross = deriv.stdenv.buildPlatform != deriv.stdenv.targetPlatform;
-      # Make sure we don't remove our functions
-      isFunction = lib.isFunction deriv;
-    in
-    isFunction || (!broken) && availableOnHost || isCross
-  )) catppuccinPackages;
+  packages = lib.filterAttrs (
+    name: deriv:
+    if name == "sources" || lib.isFunction deriv then
+      false
+    else
+      let
+        # Only export packages available on the current system, *unless* they are being cross compiled
+        availableOnHost = lib.meta.availableOn pkgs.stdenv.hostPlatform deriv;
+        # `nix flake check` doesn't like broken packages
+        broken = deriv.meta.broken or false;
+        isCross = deriv.stdenv.buildPlatform != deriv.stdenv.targetPlatform;
+      in
+      (!broken) && availableOnHost || isCross
+  ) catppuccinPackages;
 
   shell = import ./shell.nix { inherit pkgs; };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769018530,
-        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
         "type": "github"
       },
       "original": {

--- a/modules/nixos/gtk.nix
+++ b/modules/nixos/gtk.nix
@@ -5,7 +5,6 @@
   pkgs,
   ...
 }:
-
 let
   cfg = config.catppuccin.gtk;
 in
@@ -25,7 +24,7 @@ in
         && (config.services.desktopManager.gnome.enable || config.services.displayManager.gdm.enable)
       )
       {
-        services.displayManager.environment.XDG_DATA_DIRS = (
+        services.displayManager.generic.environment.XDG_DATA_DIRS = (
           (lib.makeSearchPath "share" [
             (pkgs.catppuccin-papirus-folders.override { inherit (cfg.icon) accent flavor; })
           ])


### PR DESCRIPTION
## Summary
Renamed `services.displayManager.environment` to `services.displayManager.generic.environment` in `modules/nixos/gtk.nix` to fix evaluation warning.

This option has been renamed in NixOS, and the current usage causes an evaluation warning:
`trace: evaluation warning: The option services.displayManager.environment defined in .../modules/nixos/gtk.nix has been renamed to services.displayManager.generic.environment.`