### PR TITLE
fix(cursors): no xorg

### DIFF
--- a/pkgs/cursors/package.nix
+++ b/pkgs/cursors/package.nix
@@ -7,7 +7,7 @@
   python3,
   whiskers,
   xcur2png,
-  xorg,
+  xcursorgen,
   zip,
 }:
 
@@ -23,7 +23,7 @@ buildCatppuccinPort (finalAttrs: {
     just
     whiskers
     xcur2png
-    xorg.xcursorgen
+    xcursorgen
     zip
   ];
 


### PR DESCRIPTION
it seems we have finally bid adieu to the xorg namespace. thank god