### PR TITLE
feat(fish)!: apply static themes

### DIFF
--- a/modules/home-manager/fish.nix
+++ b/modules/home-manager/fish.nix
@@ -1,7 +1,6 @@
 { catppuccinLib }:
 {
   config,
-  options,
   lib,
   ...
 }:
@@ -12,23 +11,14 @@ let
   cfg = config.catppuccin.fish;
   enable = cfg.enable && config.programs.fish.enable;
 
-  isLatte = cfg.flavor == "latte";
-  flavor = if isLatte then "mocha" else cfg.flavor;
-
-  themeName = "Catppuccin ${lib.toSentenceCase flavor}";
+  themeName = "Catppuccin ${lib.toSentenceCase cfg.flavor}";
 in
 
 {
   options.catppuccin.fish = catppuccinLib.mkCatppuccinOption { name = "fish"; };
 
   config = lib.mkIf enable {
-    # if the user has explicitly chosen Latte, that means they probally haven't
-    # seen the note that latte is included in every theme, so lets warn them
-    warnings = lib.optional (
-      isLatte && (options.catppuccin.fish.flavor.highestPrio != (lib.mkOptionDefault { }).priority)
-    ) "fish by default uses Latte as the light theme, defaulting to Mocha.";
-
-    xdg.configFile."fish/themes/${themeName}.theme".source = "${sources.fish}/${themeName}.theme";
+    xdg.configFile."fish/themes/${themeName}.theme".source = "${sources.fish}/static/${themeName}.theme";
 
     programs.fish.shellInit = ''
       fish_config theme choose "${themeName}"

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -75,9 +75,9 @@
     "rev": "1aa345a3312f0a649068418679ceb81a9c599d36"
   },
   "fish": {
-    "hash": "sha256-5CXdzym6Vp+FbKTVBtVdWoh3dODudADIzOLXIyIIxgQ=",
-    "lastModified": "2026-01-06",
-    "rev": "521560ce2075ca757473816aa31914215332bac9"
+    "hash": "sha256-jn2YoybaDY2gQgqmVGi9GPeRWn/H6IHnzxi/VcihIYM=",
+    "lastModified": "2026-02-17",
+    "rev": "bc201afe737fa0c8884ffcef206217f8aac88866"
   },
   "foot": {
     "hash": "sha256-bpGVDESE6Pr7kaFgfAWJ/5KC9mRPlv2ciYwRr6jcIKs=",


### PR DESCRIPTION
catppuccin/fish/pull/39 added static themes for fish based on discussion in https://github.com/catppuccin/fish/issues/38.

This disables dynamic light/dark theming in fish which is a breaking change, but imho more in the spirit of nix. It might be worth considering adding a `dynamic` flag to catppuccin/nix to enable dynamic light/dark switching when possible?

Fixes #847