### PR TITLE
fix(opencode): move theme to programs.opencode.tui

### DIFF
--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -19,7 +19,7 @@ in
 {
   options.catppuccin.opencode = catppuccinLib.mkCatppuccinOption { name = "opencode"; };
   config = lib.mkIf enable {
-    programs.opencode.settings = {
+    programs.opencode.tui = {
       theme = themeName;
     };
   };


### PR DESCRIPTION
In nix-community/home-manager@1089b2c  the home manager module was updated to support OpenCode v1.2.15+, which  requires TUI-specific settings like theme in a separate tui.json file. 

This fixes the deprecation warning about programs.opencode.settings containing TUI-specific keys.