### PR TITLE
feat(home-manager): add support for hyprtoolkit

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -32,6 +32,7 @@
   ./helix.nix
   ./hyprland.nix
   ./hyprlock.nix
+  ./hyprtoolkit.nix
   ./imv.nix
   ./k9s.nix
   ./kitty.nix

--- a/modules/home-manager/hyprtoolkit.nix
+++ b/modules/home-manager/hyprtoolkit.nix
@@ -1,0 +1,21 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+
+let
+  inherit (config.catppuccin) sources;
+
+  cfg = config.catppuccin.hyprtoolkit;
+in
+
+{
+  options.catppuccin.hyprtoolkit = catppuccinLib.mkCatppuccinOption {
+    name = "hyprtoolkit";
+    accentSupport = true;
+    useGlobalEnable = false;
+  };
+
+  config = lib.mkIf cfg.enable {
+    xdg.configFile."hypr/hyprtoolkit.conf".source =
+      sources.hyprtoolkit + "/${cfg.flavor}/catppuccin-${cfg.flavor}-${cfg.accent}.conf";
+  };
+}

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -17,6 +17,7 @@ in
     # listing explicitly so we know it's tested
     glamour.enable = true;
 
+    hyprtoolkit.enable = true;
     xfce4-terminal.enable = isLinux;
 
     # we install the themes but don't apply them so we can test kvantum, qt5ct

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -139,6 +139,11 @@
     "lastModified": "2025-06-02",
     "rev": "f650895064ae80db7c0e095829fce83fd85d0b26"
   },
+  "hyprtoolkit": {
+    "hash": "sha256-D05IJCPK/9jOfqti0dlhymLBPwLf/PFtkP2nR+F1DDk=",
+    "lastModified": "2026-04-05",
+    "rev": "2074fbefdaa73cfb996006f817a03d9d288aa38c"
+  },
   "imv": {
     "hash": "sha256-4WOHc9k+NUsyFDKgDAyGfRtpFsx/KyOAE5kIv4gKhwM=",
     "lastModified": "2025-08-07",


### PR DESCRIPTION
Resolves #779

Hey, this PR adds support to hyprtoolkit as suggested in the mentioned issue.
The hyprtookit repository got added a few days ago, so I could finally add this port here.
A simple `xdg.configFile` is the best approach I could think of as a home-manager module isn't available (yet) and not really needed in this use case.

hyprtoolkit is, as its name indicates, a toolkit like gtk or qt that can be themed and preferenced by a file that's being provided by the catppuccin port.