### PR TITLE
Add support for Home Assistant

### DIFF
--- a/modules/nixos/all-modules.nix
+++ b/modules/nixos/all-modules.nix
@@ -5,6 +5,7 @@
   ./gitea.nix
   ./grub.nix
   ./gtk.nix
+  ./home-assistant.nix
   ./limine.nix
   ./plymouth.nix
   ./sddm.nix

--- a/modules/nixos/home-assistant.nix
+++ b/modules/nixos/home-assistant.nix
@@ -1,0 +1,49 @@
+{ catppuccinLib }:
+{
+  lib,
+  config,
+  ...
+}:
+let
+  inherit (config.catppuccin) sources;
+  inherit (lib) singleton toSentenceCase;
+
+  cfg = config.catppuccin.home-assistant;
+in
+{
+  options.catppuccin.home-assistant =
+    catppuccinLib.mkCatppuccinOption {
+      name = "home-assistant";
+      accentSupport = true;
+    }
+    // {
+      setDefaultAtStartup = lib.mkEnableOption "setting the default theme at Home Assistant startup" // {
+        default = true;
+        example = false;
+      };
+    };
+
+  config = lib.mkIf cfg.enable {
+    services.home-assistant.config = {
+      frontend.themes = "!include_dir_merge_named ${sources.home-assistant}";
+
+      "automation catppuccin" = lib.mkIf cfg.setDefaultAtStartup {
+        alias = "Catppuccin default theme";
+        id = "catppuccin_default_theme";
+        description = "Sets the default frontend theme to ${catppuccinLib.mkFlavorName cfg.flavor} at startup.";
+        mode = "single";
+        triggers = singleton {
+          trigger = "homeassistant";
+          event = "start";
+        };
+        actions = singleton {
+          action = "frontend.set_theme";
+          data = {
+            name = "Catppuccin ${toSentenceCase cfg.flavor} ${toSentenceCase cfg.accent}";
+            name_dark = "none";
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/tests/nixos.nix
+++ b/modules/tests/nixos.nix
@@ -23,6 +23,7 @@
     };
     forgejo.enable = true;
     gitea.enable = true;
+    home-assistant.enable = true;
 
     xserver.enable = true; # required for sddm
   };

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -129,6 +129,11 @@
     "lastModified": "2026-02-18",
     "rev": "91e071bf9b9b2b8ae176a5581fcb61c789c55cab"
   },
+  "home-assistant": {
+    "hash": "sha256-+m6lWer9a4AwmTgckhSHOKd0Oo6x9N0jjza4/F0ye3E=",
+    "lastModified": "2026-04-04",
+    "rev": "b37ada06d011fe02d487719b06e70e98ded76149"
+  },
   "hyprland": {
     "hash": "sha256-xSa/z0Pu+ioZ0gFH9qSo9P94NPkEMovstm1avJ7rvzM=",
     "lastModified": "2024-06-19",


### PR DESCRIPTION
This PR contains a pair of commits with the goal of supporting Catppuccin theming of the Home Assistant frontend (Lovelace).

The first commit implements baseline functionality. Unfortunately, Home Assistant [doesn't provide](https://github.com/home-assistant/home-assistant.io/issues/27849#issuecomment-1678565423) any means to directly set the default frontend theme declaratively, so as a workaround, I've included an optional run-at-startup automation to set the default theme at runtime.

The second commit implements `catppuccin.home-assistant.{light,dark}Flavor` to integrate with Home Assistant's built-in light/dark theming support. This is modeled loosely on #442; the gist is that the bare `flavor` option is the default value for both dark and light flavors and each can be overridden separately. This feels likely to be forward compatible with potential future solutions for separate dark/light themes (and I'd be happy to help out with that implementation, if there's interest, separately).

I've tested this (both commits) and it works exactly as expected for me on Home Assistant 2026.4.1. I'd love to have access to it on 25.11, so I'll happily submit a backport PR if this is accepted.