### PR TITLE
fix: replace old config scheme in opencode

### DIFF
--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -19,7 +19,7 @@ in
 {
   options.catppuccin.opencode = catppuccinLib.mkCatppuccinOption { name = "opencode"; };
   config = lib.mkIf enable {
-    programs.opencode.settings = {
+    programs.opencode.tui = {
       theme = themeName;
     };
   };


### PR DESCRIPTION
programs.opencode.settings contains deprecated TUI-specific keys: theme
These settings should be moved to programs.opencode.tui instead.

OpenCode v1.2.15+ requires TUI settings in a separate tui.json file. See: https://opencode.ai/docs/config#tui