### PR TITLE
fix(neovim): make config type explicit

### DIFF
--- a/modules/home-manager/neovim.nix
+++ b/modules/home-manager/neovim.nix
@@ -23,16 +23,15 @@ in
       plugins = [
         {
           plugin = config.catppuccin.sources.nvim;
+          type = "lua";
           config = ''
-            lua << EOF
-              local compile_path = vim.fn.stdpath("cache") .. "/catppuccin-nvim"
-              vim.fn.mkdir(compile_path, "p")
-              vim.opt.runtimepath:append(compile_path)
+            local compile_path = vim.fn.stdpath("cache") .. "/catppuccin-nvim"
+            vim.fn.mkdir(compile_path, "p")
+            vim.opt.runtimepath:append(compile_path)
 
-              require("catppuccin").setup(${lib.generators.toLua { } cfg.settings})
+            require("catppuccin").setup(${lib.generators.toLua { } cfg.settings})
 
-              vim.api.nvim_command("colorscheme catppuccin")
-            EOF
+            vim.api.nvim_command("colorscheme catppuccin")
           '';
         }
       ];


### PR DESCRIPTION
The default type of config language now depends on `home.stateVersion`:

```nix
programs.neovim.plugins.*.type
    Language used in config. Configurations are aggregated per-language.

    Type: one of “lua”, “viml”, “teal”, “fennel” or string

    Default:

        if lib.versionAtLeast config.home.stateVersion "26.05" then "lua" else "viml"
```

So if you run catppuccin in a `26.05` environment, the current config will break:

```
E5112: Lua chunk: /home/$USER/.config/nvim/init.lua:6: '=' expected near '<'
```

This PR changes it so that the config is explicitly typed as lua instead.