### PR TITLE
ci: checkout with default token

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.PUSH_TOKEN }}
 
       - name: Set Git user info
         run: |


### PR DESCRIPTION
don't think this token is actually needed, unless i've missed something. none of the other workflows use one. default is `github.token` which should be enough unless we need to clone private submodules etc.