### PR TITLE
Revert "ci: checkout with default token"

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PUSH_TOKEN }}
 
       - name: Set Git user info
         run: |


### PR DESCRIPTION
Reverts catppuccin/nix#902

turns out it does push, the token is implicitly stored by the checkout action and we need it to bypass the branch protections 💀 