### PR TITLE
fix(home-manager/wezterm): add settings & handle programs.wezterm.settings

### DIFF
--- a/modules/home-manager/wezterm.nix
+++ b/modules/home-manager/wezterm.nix
@@ -3,6 +3,10 @@
 let
   inherit (config.catppuccin) sources;
   cfg = config.catppuccin.wezterm;
+
+  defaultConfig = {
+    inherit (cfg) flavor accent;
+  };
 in
 {
   options.catppuccin.wezterm =
@@ -14,7 +18,20 @@ in
       apply = lib.mkOption {
         type = lib.types.bool;
         default = false;
-        description = "Apply Catppuccin theme to WezTerm.";
+        description = ''
+          Apply Catppuccin theme to WezTerm
+
+          :::note
+          This option has no effect if you are using {option}`programs.wezterm.settings`
+          :::
+        '';
+      };
+
+      settings = lib.mkOption {
+        description = "Extra settings that will be passed to the setup function.";
+        default = { };
+        type = lib.types.submodule { freeformType = lib.types.attrsOf lib.types.anything; };
+        apply = lib.recursiveUpdate defaultConfig;
       };
     };
 
@@ -23,17 +40,15 @@ in
       extraConfig = lib.mkBefore (
         ''
           local catppuccin_plugin = "${sources.wezterm}/plugin/init.lua"
-          local catppuccin_config = {
-            flavor = "${cfg.flavor}",
-            accent = "${cfg.accent}",
-          }
+          local catppuccin_config = ${lib.generators.toLua { } cfg.settings}
         ''
-        + lib.optionalString cfg.apply ''
+        + lib.optionalString ((config.programs.wezterm.settings == { }) && cfg.apply) ''
           local config = {}
           if wezterm.config_builder then
             config = wezterm.config_builder()
           end
-
+        ''
+        + lib.optionalString ((config.programs.wezterm.settings != { }) || cfg.apply) ''
           dofile("${sources.wezterm}/plugin/init.lua").apply_to_config(config, catppuccin_config)
         ''
       );


### PR DESCRIPTION
here i've copied the settings concept that we have in catppuccin.nvim. and i've essentially soft deprecated `apply` for people who use `programs.wezterm.settings` and i think this is a much better use. maybe we should also warn here too.

closes #909 

@kitgxrl whats your thoughts? :D