### PR TITLE
fix: convert lastModified to string

### DIFF
--- a/pkgs/buildCatppuccinPort/package.nix
+++ b/pkgs/buildCatppuccinPort/package.nix
@@ -19,7 +19,7 @@ lib.extendMkDerivation {
     {
       pname = args.pname or "catppuccin-${finalAttrs.port}";
       version =
-        args.version or ("0" + lib.optionalString (lastModified != null) "-unstable-${lastModified}");
+        args.version or ("0" + lib.optionalString (lastModified != null) "-unstable-${builtins.toString lastModified}");
 
       src =
         args.src or sources.${finalAttrs.port} or (fetchCatppuccinPort {

--- a/pkgs/buildCatppuccinPort/package.nix
+++ b/pkgs/buildCatppuccinPort/package.nix
@@ -19,7 +19,7 @@ lib.extendMkDerivation {
     {
       pname = args.pname or "catppuccin-${finalAttrs.port}";
       version =
-        args.version or ("0" + lib.optionalString (lastModified != null) "-unstable-${builtins.toString lastModified}");
+        args.version or ("0" + lib.optionalString (lastModified != null) "-unstable-${toString lastModified}");
 
       src =
         args.src or sources.${finalAttrs.port} or (fetchCatppuccinPort {

--- a/pkgs/nvim/package.nix
+++ b/pkgs/nvim/package.nix
@@ -10,7 +10,7 @@ in
 
 vimUtils.buildVimPlugin rec {
   pname = "catppuccin-nvim";
-  version = "0${lib.optionalString (src ? "lastModified") "-unstable-${builtins.toString src.lastModified}"}";
+  version = "0${lib.optionalString (src ? "lastModified") "-unstable-${toString src.lastModified}"}";
 
   src = sources.${portName};
 

--- a/pkgs/nvim/package.nix
+++ b/pkgs/nvim/package.nix
@@ -10,7 +10,7 @@ in
 
 vimUtils.buildVimPlugin rec {
   pname = "catppuccin-nvim";
-  version = "0${lib.optionalString (src ? "lastModified") "-unstable-${src.lastModified}"}";
+  version = "0${lib.optionalString (src ? "lastModified") "-unstable-${builtins.toString src.lastModified}"}";
 
   src = sources.${portName};
 

--- a/pkgs/tmux/package.nix
+++ b/pkgs/tmux/package.nix
@@ -10,7 +10,7 @@ in
 
 tmuxPlugins.mkTmuxPlugin rec {
   pluginName = "catppuccin";
-  version = "0${lib.optionalString (src ? "lastModified") "-unstable-${src.lastModified}"}";
+  version = "0${lib.optionalString (src ? "lastModified") "-unstable-${builtins.toString src.lastModified}"}";
 
   src = sources.${portName};
 

--- a/pkgs/tmux/package.nix
+++ b/pkgs/tmux/package.nix
@@ -10,7 +10,7 @@ in
 
 tmuxPlugins.mkTmuxPlugin rec {
   pluginName = "catppuccin";
-  version = "0${lib.optionalString (src ? "lastModified") "-unstable-${builtins.toString src.lastModified}"}";
+  version = "0${lib.optionalString (src ? "lastModified") "-unstable-${toString src.lastModified}"}";
 
   src = sources.${portName};
 


### PR DESCRIPTION
this allows using unix timestamps from flakes without failing evaluation

closes #913 

used ripgrep to look for all occurences of `lastModified`, hope i didn't miss anything