### PR TITLE
feat(home-manager/kvantum): use qt.kvantum options

### DIFF
--- a/modules/home-manager/kvantum.nix
+++ b/modules/home-manager/kvantum.nix
@@ -19,21 +19,12 @@ in
       accentSupport = true;
     }
     // {
-      apply = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Applies the theme by overwriting `$XDG_CONFIG_HOME/Kvantum/kvantum.kvconfig`.
-          If this is disabled, you must manually set the theme (e.g. by using `kvantummanager`).
-        '';
-      };
-
       assertStyle = lib.mkOption {
         type = lib.types.bool;
         default = true;
         example = false;
         description = ''
-          Wether to assert that {option}`qt.style.name` is set to `"kvantum"` when Kvantum themes are enabled.
+          Whether to assert that {option}`qt.style.name` is set to `"kvantum"` when Kvantum themes are enabled.
         '';
       };
     };
@@ -49,14 +40,10 @@ in
       }
     ];
 
-    xdg.configFile = {
-      "Kvantum/${themeName}".source = "${config.catppuccin.sources.kvantum}/share/Kvantum/${themeName}";
-      "Kvantum/kvantum.kvconfig" = lib.mkIf cfg.apply {
-        text = ''
-          [General]
-          theme=${themeName}
-        '';
-      };
+    qt.kvantum = {
+      enable = true;
+      settings.General.theme = themeName;
+      themes = [ config.catppuccin.sources.kvantum ];
     };
   };
 }


### PR DESCRIPTION
Uses the kvantum module present in home-manager instead of overwriting config files.
It currently needs `kvantum.enable` (upstream PR to fix that https://github.com/nix-community/home-manager/pull/9269) 
and it adds every theme's files into `.config/Kvantum`

Also fixed a typo.