### PR TITLE
fix(plymouth): fix path in existing themes files

### DIFF
--- a/pkgs/plymouth/package.nix
+++ b/pkgs/plymouth/package.nix
@@ -9,7 +9,7 @@ buildCatppuccinPort (finalAttrs: {
   dontCatppuccinBuild = true;
 
   postPatch = ''
-    substituteInPlace plymouth.tera \
+    substituteInPlace themes/**/*.plymouth \
       --replace-fail '/usr' '${placeholder "out"}'
   '';
 


### PR DESCRIPTION
this fix should allow the plymouth theme to work again, which it doesn't currently.

the plymouth package is not performing a build. instead it is just copying the existing built themes from the source repo. however, the code to fix the ImageDir paths in the themes was changed to operate on the source template instead of the built themes like it used to. this change reverts that.

perhaps a better change would be to actually perform the build here in this package, but that is a more involved change due to the images needing to be converted to pngs. for now, this is the simple fix to get the theme working again.