### PR TITLE
chore(vscode): update hash

### DIFF
--- a/pkgs/vscode/package.nix
+++ b/pkgs/vscode/package.nix
@@ -35,7 +35,7 @@ vscode-utils.buildVscodeExtension (finalAttrs: {
       pnpmWorkspaces
       ;
     fetcherVersion = 3;
-    hash = "sha256-DE0mHkBlV0RkrEmtIXnzKaiXOK8vgcCx3z7b49zzBhc=";
+    hash = "sha256-a1er5btH6aYRnKgpyW1UU8fgsuZZO72+/JkYSMaYKSg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
A mismatched hash causes a rebuild to fail with `catppuccin.vscode.profiles.<name>.enable` set to `true`

<img width="506" height="46" alt="image" src="https://github.com/user-attachments/assets/62580a29-1164-4e48-a0ef-c27766164043" />
