### PR TITLE
feat(home-manager): add support for obsidian

### DIFF
--- a/modules/home-manager/all-modules.nix
+++ b/modules/home-manager/all-modules.nix
@@ -47,6 +47,7 @@
   ./newsboat.nix
   ./nushell.nix
   ./obs.nix
+  ./obsidian.nix
   ./opencode.nix
   ./polybar.nix
   ./qt5ct.nix

--- a/modules/home-manager/obsidian.nix
+++ b/modules/home-manager/obsidian.nix
@@ -1,0 +1,22 @@
+{ catppuccinLib }:
+{ config, lib, ... }:
+
+let
+  inherit (config.catppuccin) sources;
+
+  cfg = config.catppuccin.obsidian;
+  enable = cfg.enable && config.programs.obsidian.enable;
+in
+
+{
+  options.catppuccin.obsidian = catppuccinLib.mkCatppuccinOption { name = "obsidian"; };
+
+  config = lib.mkIf enable {
+    programs.obsidian.defaultSettings.themes = [
+      {
+        enable = true;
+        pkg = sources.obsidian;
+      }
+    ];
+  };
+}

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -80,6 +80,7 @@ in
     neovim.enable = true;
     newsboat.enable = true;
     obs-studio.enable = isLinux;
+    obsidian.enable = false; # unfree packages aren't allowed in CI
     opencode.enable = true;
     qutebrowser.enable = false; # broken package due to python3.13-lxml-html-clean-0.4.2
     rio.enable = true;

--- a/pkgs/obsidian/package.nix
+++ b/pkgs/obsidian/package.nix
@@ -1,0 +1,13 @@
+{ buildCatppuccinPort }:
+buildCatppuccinPort {
+  port = "obsidian";
+
+  dontCatppuccinBuild = true;
+  dontCatppuccinInstall = true;
+
+  postInstall = ''
+    mkdir -p $out
+    cp ./manifest.json $out/manifest.json
+    cp ./theme.css $out/theme.css
+  '';
+}

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -219,6 +219,11 @@
     "lastModified": "2026-04-05",
     "rev": "94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37"
   },
+  "obsidian": {
+    "hash": "sha256-uB0a2nSZkHHf65xBYXyNh50vaAiqdEpKQVf3eXnCVlE=",
+    "lastModified": "2026-03-11",
+    "rev": "55aa9c9036a9df864593fdaedb2a227d3823fb06"
+  },
   "palette": {
     "hash": "sha256-hsy+GhuM4MSjnwGq1YJSLBFIbVm67SSdPRgObP00mxw=",
     "lastModified": "2026-03-21",


### PR DESCRIPTION
Fixed version of #939

Note that `obsidian` is listed as an `unfree` package, thus requiring the changes to `dev/flake.nix`. There are other options that I'd be happy to switch to if desired:

1. Use the unfree package filter (`nixpkgs.config.allowUnfreePredicate`)
2. Disable testing for `obsidian` 