### PR TITLE
fix(pkgs/firefox): appease absolute path lint

### DIFF
--- a/pkgs/firefox/package.nix
+++ b/pkgs/firefox/package.nix
@@ -14,7 +14,7 @@ buildCatppuccinPort {
   ];
 
   yarnOfflineCache = fetchYarnDeps {
-    yarnLock = sources.firefox + /yarn.lock;
+    yarnLock = "${sources.firefox}/yarn.lock";
     hash = "sha256-EWx1/kujC6HBSJr6d4sTlFwANbZqBQ3FHetHcbMtiVU=";
   };
 


### PR DESCRIPTION
Configs using [lint-absolute-path-literals](https://nix.dev/manual/nix/2.34/command-ref/conf-file#conf-lint-absolute-path-literals) either spit out a warning or straight up fail to evaluate.