### PR TITLE
feat!(home-manager/gemini-cli): remove

### DIFF
--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780593650,
-        "narHash": "sha256-CHo7k65YTL3HY+WQVedDTupji+LMgNlKCdrtRHZFAK4=",
+        "lastModified": 1780679734,
+        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "447fd9ff62501dae7206dfe180ee89f8de27b7d5",
+        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
         "type": "github"
       },
       "original": {

--- a/modules/home-manager/gemini-cli.nix
+++ b/modules/home-manager/gemini-cli.nix
@@ -1,22 +1,15 @@
-{ catppuccinLib }:
-{ config, lib, ... }:
-
-let
-  inherit (config.catppuccin) sources;
-
-  cfg = config.catppuccin.gemini-cli;
-  theme = lib.importJSON "${sources.gemini-cli}/catppuccin-${cfg.flavor}.json";
-in
+{ ... }:
+{ lib, ... }:
 
 {
-  options.catppuccin.gemini-cli = catppuccinLib.mkCatppuccinOption { name = "gemini-cli"; };
-
-  config = lib.mkIf (config.catppuccin.enable && cfg.enable) {
-    programs.gemini-cli = {
-      settings.ui = {
-        theme = theme.name;
-        customThemes.${theme.name} = theme;
-      };
-    };
-  };
+  imports = [
+    (lib.mkRemovedOptionModule [ "catppuccin" "gemini-cli" "enable" ] ''
+      Upstream home-manager removed gemini-cli in favor of the
+      antigravity-cli which no longer supports the catppuccin theme.
+    '')
+    (lib.mkRemovedOptionModule [ "catppuccin" "gemini-cli" "flavor" ] ''
+      Upstream home-manager removed gemini-cli in favor of the
+      antigravity-cli which no longer supports the catppuccin theme.
+    '')
+  ];
 }

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -61,7 +61,6 @@ in
     freetube.enable = isLinux;
     fuzzel.enable = isLinux;
     fzf.enable = true;
-    gemini-cli.enable = true;
     gh-dash.enable = true;
     ghostty.enable = isLinux;
     git.enable = true;

--- a/pkgs/sources.json
+++ b/pkgs/sources.json
@@ -89,11 +89,6 @@
     "lastModified": "2026-02-20",
     "rev": "879879da8a7dc58f173b4cd7987723fd19bef6d5"
   },
-  "gemini-cli": {
-    "hash": "sha256-ISUr8Gnknb+8nnlsGbP2aVXAxQtBPbiaTc7MqsecBk4=",
-    "lastModified": "2026-01-15",
-    "rev": "6b78ab52a0569cac80158c643e7699d0a116aebc"
-  },
   "gh-dash": {
     "hash": "sha256-Pm5PkfyFqBZQ+L0cu6b66yiIE7hpT7z062xm9khxfc8=",
     "lastModified": "2026-04-14",


### PR DESCRIPTION
closes https://github.com/catppuccin/nix/issues/974 

@SymphonySimper as far as i could tell from the [docs](https://antigravity.google/docs/cli-reference) the only option is `colorScheme` which doesn't support custom keys options.