### PR TITLE
chore(home-manager/gh-dash): use includes directive

### DIFF
--- a/modules/home-manager/gh-dash.nix
+++ b/modules/home-manager/gh-dash.nix
@@ -16,7 +16,7 @@ in
 
   config = lib.mkIf (config.catppuccin.enable && cfg.enable) {
     programs.gh-dash = {
-      settings = catppuccinLib.importYAML theme;
+      settings.include = [ theme ];
     };
   };
 }


### PR DESCRIPTION
pending on a new gh-dash release