### PR TITLE
Revert "feat(home-manager/cursors): support global enable (#1000)"

### DIFF
--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783479733,
-        "narHash": "sha256-d/JatqgG+Pmo+IuCTZfnrEAPWU3fdha48GQeXuFO+bE=",
+        "lastModified": 1783024095,
+        "narHash": "sha256-oE+TNK98Pl7nHW4VU1oBvUKD5JR45U+py/NJmLoTNHI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cee3f0e7fec85d80c149c7afc29926747f7bd3c2",
+        "rev": "a4d410db95a6416d1008049330bd86b85b5db45a",
         "type": "github"
       },
       "original": {

--- a/modules/home-manager/cursors.nix
+++ b/modules/home-manager/cursors.nix
@@ -2,7 +2,6 @@
 {
   options,
   config,
-  pkgs,
   lib,
   ...
 }:
@@ -36,7 +35,9 @@ in
   options.catppuccin.cursors =
     catppuccinLib.mkCatppuccinOption {
       name = "pointer cursors";
-      useGlobalEnable = pkgs.stdenv.hostPlatform.isLinux;
+      # NOTE: We exclude this as there is no `enable` option in the upstream
+      # module to guard it
+      useGlobalEnable = false;
     }
     // {
       accent = lib.mkOption {


### PR DESCRIPTION
This reverts commit d88e830b7bff7a591a49d031f6895312c15c27b1.