### PR TITLE
feat(home-manager/cursors): support global enable v2

### DIFF
--- a/modules/home-manager/cursors.nix
+++ b/modules/home-manager/cursors.nix
@@ -2,6 +2,7 @@
 {
   options,
   config,
+  pkgs,
   lib,
   ...
 }:
@@ -35,9 +36,7 @@ in
   options.catppuccin.cursors =
     catppuccinLib.mkCatppuccinOption {
       name = "pointer cursors";
-      # NOTE: We exclude this as there is no `enable` option in the upstream
-      # module to guard it
-      useGlobalEnable = false;
+      useGlobalEnable = pkgs.stdenv.hostPlatform.isLinux;
     }
     // {
       accent = lib.mkOption {

--- a/modules/tests/home.nix
+++ b/modules/tests/home.nix
@@ -20,6 +20,9 @@ in
     hyprtoolkit.enable = true;
     xfce4-terminal.enable = isLinux;
 
+    # `home.pointerCursor` asserts the Linux platform, so only enable there
+    cursors.enable = isLinux;
+
     # we install the themes but don't apply them so we can test kvantum, qt5ct
     # and qt6ct
     kvantum.assertStyle = false;


### PR DESCRIPTION
Latest home manager commit [1aac8895](https://github.com/nix-community/home-manager/commit/1aac8895fea6fcabc6a0184c63a80fb2f99fd208) changed the default behavior of `home.pointerCursor.enable`, and now requires `home.pointerCursor.enable = true` to be explicitly set.

Below is the error message generated

```shell
evaluation warning: fred profile: Relying on `home.pointerCursor` to enable cursor config generation is deprecated.
Please update your configuration to explicitly set:

home.pointerCursor.enable = true;
```

Additionally, the test module required a small change to assert the cursor only on linux platforms, because upstream [home-cursor.nix](https://github.com/nix-community/home-manager/blob/1aac8895fea6fcabc6a0184c63a80fb2f99fd208/modules/config/home-cursor.nix#L177) asserts this is only a valid option on linux.