### PR TITLE
fix(foot): use the correct config path

### DIFF
--- a/modules/home-manager/foot.nix
+++ b/modules/home-manager/foot.nix
@@ -13,7 +13,7 @@ in
   config = lib.mkIf (config.catppuccin.enable && cfg.enable) {
     programs.foot = {
       settings = {
-        main.include = sources.foot + "/catppuccin-${cfg.flavor}.ini";
+        main.include = sources.foot + "/static/catppuccin-${cfg.flavor}.ini";
       };
     };
   };


### PR DESCRIPTION
Repo structure in catpppuccin/foot has changed:
themes/catppuccin-*.ini: dark themes only, with support for light/dark switching
themes/static/catppuccin-*.ini: all themes, in legacy format without light/dark switching

Current behavior breaks the latte flavor for foot.