### PR TITLE
home-manager/cursors: explicitly set home.pointerCursor.enable

### DIFF
--- a/modules/home-manager/cursors.nix
+++ b/modules/home-manager/cursors.nix
@@ -48,6 +48,7 @@ in
 
   config = lib.mkIf enable {
     home.pointerCursor = {
+      enable = true;
       name = "catppuccin-${cfg.flavor}-${cfg.accent}-cursors";
       package = sources.cursors."${cfg.flavor}${lib.toSentenceCase cfg.accent}";
     };


### PR DESCRIPTION
Fixes the following home-manager evaluation warning:

```
evaluation warning: <user> profile: Relying on `home.pointerCursor` to enable cursor config generation is deprecated.
                    Please update your configuration to explicitly set:
                      home.pointerCursor.enable = true;
```

This sets \`home.pointerCursor.enable = true\` explicitly wherever the module previously relied on implicit enabling.